### PR TITLE
Generate did.json from type instead of string

### DIFF
--- a/cmd/bffsrv/main.go
+++ b/cmd/bffsrv/main.go
@@ -134,12 +134,17 @@ func runE(log *zap.Logger) error {
 		hostname = "feed.furryli.st"
 	}
 	listenAddr := ":1337"
-	srv := feedserver.New(
+	srv, err := feedserver.New(
 		log.Named("feed_server"),
 		queries,
 		hostname,
 		listenAddr,
 	)
+
+	if err != nil {
+		return fmt.Errorf("creating feed server: %w", err)
+	}
+
 	eg.Go(func() error {
 		log.Info("feed server listening", zap.String("addr", srv.Addr))
 		go func() {

--- a/feedserver/server.go
+++ b/feedserver/server.go
@@ -33,9 +33,16 @@ func New(
 	queries *store.Queries,
 	hostname string,
 	listenAddr string,
-) *http.Server {
+) (*http.Server, error) {
 	mux := &http.ServeMux{}
-	mux.Handle(didHandler(hostname))
+
+	didName, didHandler, err := didHandler(hostname)
+
+	if err != nil {
+		return nil, err
+	}
+
+	mux.Handle(didName, didHandler)
 	mux.Handle(getFeedSkeletonHandler(log, queries))
 	mux.Handle(describeFeedGeneratorHandler(log, hostname))
 	mux.Handle(rootHandler(log))
@@ -43,5 +50,5 @@ func New(
 	return &http.Server{
 		Addr:    listenAddr,
 		Handler: mux,
-	}
+	}, nil
 }


### PR DESCRIPTION
This changes the `did.json` generation from an Sprintf to a type-based one. Though, instead of using multiple structs, we're just using a `map[string]any` to keep it simple while still having the advantage of not writing JSON directly.

While Go doesn't maintain an order of map keys, the generated JSON at `/.well-known/did.json` is semantically identical to the current JSON.

## Example in dev

```
{"@context":["https://www.w3.org/ns/did/v1"],"id":"did:web:dev-feed.ottr.sh","service":[{"id":"#bsky_fg","serviceEndpoint":"https://dev-feed.ottr.sh","type":"BskyFeedGenerator"}]}
```