### PR TITLE
Handle deletion events from firehose ingest

### DIFF
--- a/bluesky/bluesky.go
+++ b/bluesky/bluesky.go
@@ -2,11 +2,14 @@ package bluesky
 
 import (
 	"context"
+	"fmt"
+	"strings"
+	"time"
+
 	"github.com/bluesky-social/indigo/api/atproto"
 	"github.com/bluesky-social/indigo/api/bsky"
 	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
-	"time"
 )
 
 type UnauthClient struct {
@@ -147,4 +150,21 @@ func (c *Client) Follow(
 		return err
 	}
 	return nil
+}
+
+var ErrMalformedRecordUri = fmt.Errorf("malformed record uri")
+
+// Parse the namespace ID from a full record URI, such
+// as app.bsky.feed.post or app.bsky.graph.follow.
+//
+// Errors with a `ErrMalformedRecordUri` if the URI is
+// not a _parseable_ record URI.
+func ParseNamespaceID(recordUri string) (string, error) {
+	parts := strings.Split(recordUri, "/")
+
+	if len(parts) <= 3 {
+		return "", ErrMalformedRecordUri
+	}
+
+	return parts[3], nil
 }

--- a/bluesky/bluesky_test.go
+++ b/bluesky/bluesky_test.go
@@ -1,0 +1,19 @@
+package bluesky_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/strideynet/bsky-furry-feed/bluesky"
+)
+
+func TestParseNamespaceID(t *testing.T) {
+	assert := assert.New(t)
+
+	nsid, err := bluesky.ParseNamespaceID("at://did:plc:bv2ckchoc76yobfhkrrie4g6/app.bsky.feed.post/3jzswcmgyao2v")
+	assert.Nil(err)
+	assert.Equal(nsid, "app.bsky.feed.post")
+
+	_, err = bluesky.ParseNamespaceID("at://wrong-namespace")
+	assert.Equal(err, bluesky.ErrMalformedRecordUri)
+}

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,12 @@ require (
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
+
+require (
 	cloud.google.com/go/compute v1.19.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/trace v1.9.0 // indirect
@@ -94,6 +100,7 @@ require (
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
+	github.com/stretchr/testify v1.8.4
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/otel/metric v0.38.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -478,7 +478,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.10/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=

--- a/ingester/handle_feed_like.go
+++ b/ingester/handle_feed_like.go
@@ -3,12 +3,13 @@ package ingester
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/bluesky-social/indigo/api/bsky"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/strideynet/bsky-furry-feed/bluesky"
 	"github.com/strideynet/bsky-furry-feed/store"
 	"go.uber.org/zap"
-	"time"
 )
 
 func (fi *FirehoseIngester) handleFeedLikeCreate(
@@ -43,6 +44,23 @@ func (fi *FirehoseIngester) handleFeedLikeCreate(
 	)
 	if err != nil {
 		return fmt.Errorf("creating candidate like: %w", err)
+	}
+
+	return nil
+}
+
+func (fi *FirehoseIngester) handleFeedLikeDelete(
+	ctx context.Context,
+	log *zap.Logger,
+	recordUri string,
+) error {
+	ctx, span := tracer.Start(ctx, "firehose_ingester.handle_feed_like_delete")
+	defer span.End()
+
+	if err := fi.queries.SoftDeleteCandidateLike(
+		ctx, recordUri,
+	); err != nil {
+		return fmt.Errorf("deleting candidate like: %w", err)
 	}
 
 	return nil

--- a/ingester/handle_graph_follow.go
+++ b/ingester/handle_graph_follow.go
@@ -3,12 +3,13 @@ package ingester
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/bluesky-social/indigo/api/bsky"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/strideynet/bsky-furry-feed/bluesky"
 	"github.com/strideynet/bsky-furry-feed/store"
 	"go.uber.org/zap"
-	"time"
 )
 
 func (fi *FirehoseIngester) handleGraphFollowCreate(
@@ -43,6 +44,23 @@ func (fi *FirehoseIngester) handleGraphFollowCreate(
 	)
 	if err != nil {
 		return fmt.Errorf("creating candidate follow: %w", err)
+	}
+
+	return nil
+}
+
+func (fi *FirehoseIngester) handleFeedFollowDelete(
+	ctx context.Context,
+	log *zap.Logger,
+	recordUri string,
+) error {
+	ctx, span := tracer.Start(ctx, "firehose_ingester.handle_feed_follow_delete")
+	defer span.End()
+
+	if err := fi.queries.SoftDeleteCandidateFollow(
+		ctx, recordUri,
+	); err != nil {
+		return fmt.Errorf("deleting candidate follow: %w", err)
 	}
 
 	return nil

--- a/ingester/ingester.go
+++ b/ingester/ingester.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -19,6 +18,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/strideynet/bsky-furry-feed/bluesky"
 	"github.com/strideynet/bsky-furry-feed/store"
 	typegen "github.com/whyrusleeping/cbor-gen"
 	"go.opentelemetry.io/otel"
@@ -315,7 +315,7 @@ func (fi *FirehoseIngester) handleRecordDelete(
 		return
 	}
 
-	nsid, err := parseNsid(recordUri)
+	nsid, err := bluesky.ParseNamespaceID(recordUri)
 
 	if err != nil {
 		return
@@ -335,14 +335,4 @@ func (fi *FirehoseIngester) handleRecordDelete(
 	}
 
 	return
-}
-
-func parseNsid(recordUri string) (string, error) {
-	parts := strings.Split(recordUri, "/")
-
-	if len(parts) < 3 {
-		return "", fmt.Errorf("malformed record uri '%s'", recordUri)
-	}
-
-	return parts[3], nil
 }

--- a/ingester/ingester.go
+++ b/ingester/ingester.go
@@ -5,6 +5,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/bluesky-social/indigo/api/atproto"
 	"github.com/bluesky-social/indigo/api/bsky"
 	"github.com/bluesky-social/indigo/events"
@@ -21,9 +26,6 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
-	"net/http"
-	"sync"
-	"time"
 )
 
 var tracer = otel.Tracer("github.com/strideynet/bsky-furry-feed/ingester")
@@ -170,34 +172,44 @@ func (fi *FirehoseIngester) handleCommit(ctx context.Context, evt *atproto.SyncS
 		return fmt.Errorf("reading repo from car %w", err)
 	}
 	for _, op := range evt.Ops {
-		// Ignore any op that isn't a record create.
-		if repomgr.EventKind(op.Action) != repomgr.EvtKindCreateRecord {
-			continue
-		}
 		log := log.With(
 			zap.String("op.action", op.Action),
 			zap.String("op.path", op.Path),
 		)
 
-		recordCid, record, err := rr.GetRecord(ctx, op.Path)
-		if err != nil {
-			if errors.Is(err, lexutil.ErrUnrecognizedType) {
-				continue
-			}
-			return fmt.Errorf("getting record for op: %w", err)
-		}
-		// Ensure there isn't a mismatch between the reference and the found
-		// object.
-		if lexutil.LexLink(recordCid) != *op.Cid {
-			return fmt.Errorf("mismatch in record and op cid: %s != %s", recordCid, *op.Cid)
-		}
-
 		uri := fmt.Sprintf("at://%s/%s", evt.Repo, op.Path)
-		log = log.With(zap.String("record.uri", uri))
-		if err := fi.handleRecordCreate(
-			ctx, log, evt.Repo, uri, record,
-		); err != nil {
-			return fmt.Errorf("handling record create: %w", err)
+
+		switch repomgr.EventKind(op.Action) {
+		case repomgr.EvtKindCreateRecord:
+			recordCid, record, err := rr.GetRecord(ctx, op.Path)
+			if err != nil {
+				if errors.Is(err, lexutil.ErrUnrecognizedType) {
+					continue
+				}
+				return fmt.Errorf("getting record for op: %w", err)
+			}
+
+			// Ensure there isn't a mismatch between the reference and the found
+			// object.
+			if lexutil.LexLink(recordCid) != *op.Cid {
+				return fmt.Errorf("mismatch in record and op cid: %s != %s", recordCid, *op.Cid)
+			}
+
+			log = log.With(zap.String("record.uri", uri))
+
+			if err := fi.handleRecordCreate(
+				ctx, log, evt.Repo, uri, record,
+			); err != nil {
+				return fmt.Errorf("handling record create: %w", err)
+			}
+		case repomgr.EvtKindDeleteRecord:
+			log = log.With(zap.String("record.uri", uri))
+
+			if err := fi.handleRecordDelete(
+				ctx, log, uri,
+			); err != nil {
+				return fmt.Errorf("handling record delete: %w", err)
+			}
 		}
 	}
 
@@ -285,4 +297,36 @@ func (fi *FirehoseIngester) handleRecordCreate(
 	}
 
 	return nil
+}
+
+func (fi *FirehoseIngester) handleRecordDelete(
+	ctx context.Context,
+	log *zap.Logger,
+	recordUri string,
+) (err error) {
+	ctx, span := tracer.Start(ctx, "firehose_ingester.handle_record_delete")
+	defer span.End()
+
+	parts := strings.Split(recordUri, "/")
+
+	if len(parts) < 3 {
+		return fmt.Errorf("malformed record uri '%s'", recordUri)
+	}
+
+	typ := parts[3]
+
+	log.Debug("handling record delete", zap.Any("recordUri", recordUri), zap.Any("type", typ))
+
+	switch typ {
+	case "app.bsky.feed.post":
+		err = fi.handleFeedPostDelete(ctx, log, recordUri)
+	case "app.bsky.feed.like":
+		err = fi.handleFeedLikeDelete(ctx, log, recordUri)
+	case "app.bsky.graph.follow":
+		err = fi.handleFeedFollowDelete(ctx, log, recordUri)
+	default:
+		log.Debug("ignoring record create due to handled type")
+	}
+
+	return
 }

--- a/ingester/ingester.go
+++ b/ingester/ingester.go
@@ -315,17 +315,15 @@ func (fi *FirehoseIngester) handleRecordDelete(
 		return
 	}
 
-	parts := strings.Split(recordUri, "/")
+	nsid, err := parseNsid(recordUri)
 
-	if len(parts) < 3 {
-		return fmt.Errorf("malformed record uri '%s'", recordUri)
+	if err != nil {
+		return
 	}
 
-	typ := parts[3]
+	log.Debug("handling record delete", zap.Any("recordUri", recordUri), zap.Any("nsid", nsid))
 
-	log.Debug("handling record delete", zap.Any("recordUri", recordUri), zap.Any("type", typ))
-
-	switch typ {
+	switch nsid {
 	case "app.bsky.feed.post":
 		err = fi.handleFeedPostDelete(ctx, log, recordUri)
 	case "app.bsky.feed.like":
@@ -337,4 +335,14 @@ func (fi *FirehoseIngester) handleRecordDelete(
 	}
 
 	return
+}
+
+func parseNsid(recordUri string) (string, error) {
+	parts := strings.Split(recordUri, "/")
+
+	if len(parts) < 3 {
+		return "", fmt.Errorf("malformed record uri '%s'", recordUri)
+	}
+
+	return parts[3], nil
 }

--- a/store/candidate_follows.sql.go
+++ b/store/candidate_follows.sql.go
@@ -37,3 +37,17 @@ func (q *Queries) CreateCandidateFollow(ctx context.Context, arg CreateCandidate
 	)
 	return err
 }
+
+const softDeleteCandidateFollow = `-- name: SoftDeleteCandidateFollow :exec
+UPDATE
+    candidate_follows
+SET
+    deleted_at = NOW()
+WHERE
+    uri = $1
+`
+
+func (q *Queries) SoftDeleteCandidateFollow(ctx context.Context, uri string) error {
+	_, err := q.db.Exec(ctx, softDeleteCandidateFollow, uri)
+	return err
+}

--- a/store/candidate_likes.sql.go
+++ b/store/candidate_likes.sql.go
@@ -37,3 +37,17 @@ func (q *Queries) CreateCandidateLike(ctx context.Context, arg CreateCandidateLi
 	)
 	return err
 }
+
+const softDeleteCandidateLike = `-- name: SoftDeleteCandidateLike :exec
+UPDATE
+    candidate_likes
+SET
+    deleted_at = NOW()
+WHERE
+    uri = $1
+`
+
+func (q *Queries) SoftDeleteCandidateLike(ctx context.Context, uri string) error {
+	_, err := q.db.Exec(ctx, softDeleteCandidateLike, uri)
+	return err
+}

--- a/store/candidate_posts.sql.go
+++ b/store/candidate_posts.sql.go
@@ -208,7 +208,8 @@ SELECT
      WHERE
            cl.subject_uri = cp.uri
        AND ($1::TIMESTAMPTZ IS NULL OR
-            cl.indexed_at < $1)) AS likes
+            cl.indexed_at < $1)
+       AND cl.deleted_at IS NULL) AS likes
 FROM
     candidate_posts cp
         INNER JOIN candidate_actors ca ON cp.actor_did = ca.did

--- a/store/migrations/000009_add_deleted_at_columns.down.sql
+++ b/store/migrations/000009_add_deleted_at_columns.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE candidate_likes DROP COLUMN deleted_at;
+ALTER TABLE candidate_posts DROP COLUMN deleted_at;
+ALTER TABLE candidate_follows DROP COLUMN deleted_at;

--- a/store/migrations/000009_add_deleted_at_columns.up.sql
+++ b/store/migrations/000009_add_deleted_at_columns.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE candidate_likes ADD COLUMN deleted_at TIMESTAMPTZ;
+ALTER TABLE candidate_posts ADD COLUMN deleted_at TIMESTAMPTZ;
+ALTER TABLE candidate_follows ADD COLUMN deleted_at TIMESTAMPTZ;

--- a/store/models.go
+++ b/store/models.go
@@ -71,6 +71,7 @@ type CandidateFollow struct {
 	SubjectDid string
 	CreatedAt  pgtype.Timestamptz
 	IndexedAt  pgtype.Timestamptz
+	DeletedAt  pgtype.Timestamptz
 }
 
 type CandidateLike struct {
@@ -79,6 +80,7 @@ type CandidateLike struct {
 	SubjectURI string
 	CreatedAt  pgtype.Timestamptz
 	IndexedAt  pgtype.Timestamptz
+	DeletedAt  pgtype.Timestamptz
 }
 
 type CandidatePost struct {
@@ -89,4 +91,5 @@ type CandidatePost struct {
 	IsNSFW    bool
 	IsHidden  bool
 	Tags      []string
+	DeletedAt pgtype.Timestamptz
 }

--- a/store/queries/candidate_follows.sql
+++ b/store/queries/candidate_follows.sql
@@ -4,3 +4,11 @@ INSERT INTO
                      indexed_at)
 VALUES
     ($1, $2, $3, $4, $5);
+
+-- name: SoftDeleteCandidateFollow :exec
+UPDATE
+    candidate_follows
+SET
+    deleted_at = NOW()
+WHERE
+    uri = $1;

--- a/store/queries/candidate_likes.sql
+++ b/store/queries/candidate_likes.sql
@@ -4,3 +4,11 @@ INSERT INTO
                      indexed_at)
 VALUES
     ($1, $2, $3, $4, $5);
+
+-- name: SoftDeleteCandidateLike :exec
+UPDATE
+    candidate_likes
+SET
+    deleted_at = NOW()
+WHERE
+    uri = $1;

--- a/store/queries/candidate_posts.sql
+++ b/store/queries/candidate_posts.sql
@@ -76,7 +76,8 @@ SELECT
      WHERE
            cl.subject_uri = cp.uri
        AND (@cursor_timestamp::TIMESTAMPTZ IS NULL OR
-            cl.indexed_at < @cursor_timestamp)) AS likes
+            cl.indexed_at < @cursor_timestamp)
+       AND cl.deleted_at IS NULL) AS likes
 FROM
     candidate_posts cp
         INNER JOIN candidate_actors ca ON cp.actor_did = ca.did

--- a/store/queries/candidate_posts.sql
+++ b/store/queries/candidate_posts.sql
@@ -4,6 +4,14 @@ INSERT INTO
 VALUES
     ($1, $2, $3, $4, $5);
 
+-- name: SoftDeleteCandidatePost :exec
+UPDATE
+    candidate_posts
+SET
+    deleted_at = NOW()
+WHERE
+    uri = $1;
+
 -- name: GetFurryNewFeed :many
 SELECT
     cp.*
@@ -15,6 +23,7 @@ WHERE
   AND ca.status = 'approved'
   AND (@cursor_timestamp::TIMESTAMPTZ IS NULL OR
        cp.created_at < @cursor_timestamp)
+  AND cp.deleted_at IS NULL
 ORDER BY
     cp.created_at DESC
 LIMIT @_limit;
@@ -31,6 +40,7 @@ WHERE
   AND ca.status = 'approved'
   AND (@cursor_timestamp::TIMESTAMPTZ IS NULL OR
        cp.created_at < @cursor_timestamp)
+  AND cp.deleted_at IS NULL
 GROUP BY
     cp.uri
 HAVING
@@ -51,6 +61,7 @@ WHERE
   AND @tag::TEXT = ANY (cp.tags)
   AND (@cursor_timestamp::TIMESTAMPTZ IS NULL OR
        cp.created_at < @cursor_timestamp)
+  AND cp.deleted_at IS NULL
 ORDER BY
     cp.created_at DESC
 LIMIT @_limit;
@@ -74,6 +85,7 @@ WHERE
   AND ca.status = 'approved'
   AND (@cursor_timestamp::TIMESTAMPTZ IS NULL OR
        cp.indexed_at < @cursor_timestamp)
+  AND cp.deleted_at IS NULL
 ORDER BY
     cp.indexed_at DESC
 LIMIT @_limit;


### PR DESCRIPTION
This PR makes the ingest handle deletion events (unlikes, post deletions, and unfollows), so that we can soft-delete likes, posts, and follows in our database by using a newly created `deleted_at` column on all three tables.

This also ensures that deleted posts aren’t used for any of the feeds by checking `deleted_at` in the respective queries.

Closes https://github.com/strideynet/bsky-furry-feed/issues/16