### PR TITLE
Store credentials and config in .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+ENV=dev
+
+# Your handle on bsky.app and an app password generated
+# at: https://bsky.app/settings/app-passwords
+BLUESKY_USERNAME=
+BLUESKY_PASSWORD=

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ go.work
 .idea/
 infra/secrets/
 .DS_Store
+.env

--- a/cmd/bffctl/main.go
+++ b/cmd/bffctl/main.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
+
+	"github.com/joho/godotenv"
 	"github.com/strideynet/bsky-furry-feed/bluesky"
 	"github.com/urfave/cli/v2"
 	"go.uber.org/zap"
-	"os"
 )
 
 type environment struct {
@@ -36,6 +39,10 @@ func getBlueskyClient(ctx context.Context) (*bluesky.Client, error) {
 
 func main() {
 	log, _ := zap.NewDevelopment()
+
+	if err := godotenv.Load(); err != nil && !errors.Is(err, os.ErrNotExist) {
+		log.Info("could not load .env file", zap.Error(err))
+	}
 
 	var env = &environment{}
 	app := &cli.App{

--- a/cmd/bffsrv/main.go
+++ b/cmd/bffsrv/main.go
@@ -2,7 +2,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/joho/godotenv"
 	"github.com/strideynet/bsky-furry-feed/api"
 	"github.com/strideynet/bsky-furry-feed/bluesky"
 	"github.com/strideynet/bsky-furry-feed/feed"
@@ -18,9 +24,6 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sys/unix"
-	"os"
-	"os/signal"
-	"time"
 )
 
 // TODO: Better, more granular, env configuration.
@@ -48,8 +51,12 @@ func getMode() (mode, error) {
 
 func main() {
 	log, _ := zap.NewProduction()
-	err := runE(log)
-	if err != nil {
+
+	if err := godotenv.Load(); err != nil && !errors.Is(err, os.ErrNotExist) {
+		log.Fatal("could not load existing .env file", zap.Error(err))
+	}
+
+	if err := runE(log); err != nil {
 		log.Fatal("exited with error", zap.Error(err))
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -87,6 +87,7 @@ require (
 	github.com/jbenet/goprocess v0.1.4 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
+	github.com/joho/godotenv v1.5.1
 	github.com/klauspost/cpuid/v2 v2.2.4 // indirect
 	github.com/mattn/go-isatty v0.0.18 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -298,6 +298,8 @@ github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=


### PR DESCRIPTION
This adds [`godotenv`](https://github.com/joho/godotenv) to load a `.env` for the server and CLI. It is not required, which is useful for production deployments, but useful for local deployments.

A template of a complete `.env` is provided as `.env.example`.

Related to #24.