### PR TITLE
Improve developing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,9 @@ Reach out on the [Bluesky furries discord](https://discord.gg/5UNyBtnwKy) for mo
 This is also a neat example of a Bluesky feed generator written in Go! If you
 are trying to build something similar in Go, and need any advice, please learn
 what you can from the source code and ask any questions.
+
+Interested in contributing? Read our [getting started guide][developing]
+or [check out the open issues][issues].
+
+[developing]: ./docs/developing.md
+[issues]: https://github.com/strideynet/bsky-furry-feed/issues

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -1,16 +1,133 @@
 # Developing
 
-Random commands I run often:
+The Bluesky furry feed, sometimes referred to as **bff**, is written
+mostly in [Go][go]. It broadly consists of a data ingester, the feed
+generation service, and a moderation system for—among other
+uses—approving new users to the feed.
 
-```sh
-migrate create -ext sql -dir store/migrations -seq create_post_candidate
-sqlc generate --experimental
-# For local
-migrate -path store/migrations -database "postgres://bff:bff@localhost:5432/bff?sslmode=disable" up
-# For production with cloud-sql-proxy
-migrate -path store/migrations -database "postgres://noah@noahstride.co.uk@localhost:15432/bff?sslmode=disable" up
+[go]: https://go.dev
+
+## Getting started
+
+After [cloning this repository][clone], install the following required
+system dependencies if you don’t have them yet:
+
+1. The latest [Go 1.20][go] version,
+2. [Docker][docker], and
+3. [docker-compose][docker-compose] if your Docker version doesn’t
+   support running `docker compose` as subcommand of Docker.
+
+In addition to this, we’re using `sqlc` and `migrate` to manage our
+database schema. Install them by executing the following commands:
+
+```bash
+$ go install github.com/kyleconroy/sqlc/cmd/sqlc@latest
+$ go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
 ```
 
-Bluesky client with feed support: https://skyfeed.app/#/
+In order to run the ingest and feed server, you need to start a local
+development database. Start it by executing `docker-compose up -d`. If
+you want to turn it off again, execute `docker-compose down`. You can
+learn more about docker-compose [in the official docs][docker-compose].
+
+Now that your database is running, you need to initially run all database
+migrations, so that all required tables are created. You’ll need to
+re-run this any time we create a new migration.
+
+```sh
+$ migrate -path store/migrations -database "postgres://bff:bff@localhost:5432/bff?sslmode=disable" up
+1/u candidate_actors (Xms)
+2/u create_candidate_post (Xms)
+3/u create_candidate_like (Xms)
+4/u create_candidate_follow (Xms)
+...
+```
+
+For migrating the production database with `cloud-sql-proxy`, you (i.e.
+probably Noah) run the following command:
+
+```sh
+$ migrate -path store/migrations -database "postgres://noah@noahstride.co.uk@localhost:15432/bff?sslmode=disable" up
+...
+```
+
+[clone]: https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository
+[docker]: https://docs.docker.com/engine/install/#server
+[docker-compose]: https://docs.docker.com/compose/
+
+## Configuring your environment
+
+Both the server and cli need a Bluesky login to start. Copy the
+`.env.example` to `.env` and follow the instructions in there.
+
+## Running the ingest and feed server
+
+With the database running and the schema migrated, you can start the main
+bff server (aka. `bffsrv`):
+
+```sh
+$ go run ./cmd/bffsrv/
+...
+```
+
+You may also want to use the cli (aka. `bffctl`) to e.g. interact with
+the database or find a did by a user’s handle.
+
+```sh
+$ go run ./cmd/bffctl/ -e local
+NAME:
+   bffctl - The swiss army knife of any BFF operator
+...
+```
+
+By default, the ingest saves no data because no user is registered as
+so-called _candidate actor_. To add a user as candidate actor and allow
+the ingest server to collect their posts, likes, and follows, add them
+to the database using bffctl (where `HANDLE` is your Bluesky handle, such
+as `ottr.sh`):
+
+```sh
+$ go run ./cmd/bffctl/ -e local db ca add --handle HANDLE
+...
+2023-07-07T01:26:56.071+0200    INFO    bffctl/db.go:175        successfully added
+```
+
+## Migrations and queries
+
+We use `sqlc` to generate type-safe code from raw SQL queries and
+`migrate` to create & manage migrations.
+
+To create a migration, run this command in the project root where
+`NAME` is the name of your migration, such as `create_post_candidate`:
+
+```sh
+$ migrate create -ext sql -dir store/migrations -seq NAME
+/.../store/migrations/000010_NAME.up.sql
+/.../store/migrations/000010_NAME.down.sql
+```
+
+The queries in the `*.up.sql` file are executed when running the
+[`up`](#getting-started) command using migrate. To rollback the latest
+migration, run migrate’s `down` command.
+
+```sh
+$ migrate -path store/migrations -database "postgres://bff:bff@localhost:5432/bff?sslmode=disable" down 1
+10/d NAME (39.10048ms)
+```
+
+After applying a new migration or editing a query, such as in
+`store/queries/candidate_posts.sql`, we need to generate the sqlc
+bindings for the database schema and all queries:
+
+```sh
+$ sqlc generate --experimental
+```
+
+## Skyfeed
+
+While the official Bluesky client supports feeds, you may prefer using
+[SkyFeed][skyfeed], a community-created client with feed support.
 
 You need HTTPS, so use Cloudflare Tunnel or similar when developing.
+
+[skyfeed]: https://skyfeed.app/#/


### PR DESCRIPTION
This improves the `docs/developing.md` doc to ease new setups, particularly for new contributors. It doesn’t yet touch on `buf` and the moderation API but we can do that in a follow-up.

We may also want to create a `CONTRIBUTING.md` in a follow-up, which points to `docs/developing.md` but also touches on issues and pull requests.

Relates to #24.