### PR TITLE
Add CI jobs to check for sqlc diff

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -34,7 +34,7 @@ jobs:
           go-version: "1.20"
           cache: false
       - name: Install sqlc
-        run: go install github.com/kyleconroy/sqlc/cmd/sqlc@latest
+        run: go install github.com/kyleconroy/sqlc/cmd/sqlc@v1.18.0
       - run: sqlc generate
       - name: Check that sqlc queries are up-to-date
         run: git diff --exit-code

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,9 +15,26 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: "1.20"
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.53
+  check-sqlc:
+    name: Check sqlc generation
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.20"
+          cache: false
+      - name: Install sqlc
+        run: go install github.com/kyleconroy/sqlc/cmd/sqlc@latest
+      - run: sqlc generate
+      - name: Check that sqlc queries are up-to-date
+        run: git diff --exit-code

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -21,7 +21,7 @@ In addition to this, we’re using `sqlc` and `migrate` to manage our
 database schema. Install them by executing the following commands:
 
 ```bash
-$ go install github.com/kyleconroy/sqlc/cmd/sqlc@latest
+$ go install github.com/kyleconroy/sqlc/cmd/sqlc@v1.18.0
 $ go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
 ```
 


### PR DESCRIPTION
This adds one CI job to check that `sqlc generate` was executed by the developer.

Because the protobuf check fails in CI, we can do that in a follow up. See #45.

Closes #28 