### PR TITLE
Fix atproto imports due to CommonJS

### DIFF
--- a/web/admin/components/shared/bsky/description.vue
+++ b/web/admin/components/shared/bsky/description.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { RichText } from "@atproto/api";
+import * as atproto from "@atproto/api";
 import { newAgent } from "~/lib/auth";
 
 const props = defineProps<{ description: string }>();
@@ -7,7 +7,7 @@ const props = defineProps<{ description: string }>();
 const segments = ref();
 
 const updateDescription = async () => {
-  const descriptionRichText = new RichText(
+  const descriptionRichText = new atproto.RichText(
     { text: props.description },
     { cleanNewlines: true }
   );

--- a/web/admin/lib/auth.ts
+++ b/web/admin/lib/auth.ts
@@ -1,12 +1,12 @@
-import { AtpSessionData, BskyAgent } from "@atproto/api";
+import * as atproto from "@atproto/api";
 
 export const COOKIE_NAME = "furrylist-bsky-session";
 const BSKY_API = "https://bsky.social";
 
-export function newAgent(): BskyAgent {
-  const agent = new BskyAgent({ service: BSKY_API });
+export function newAgent(): atproto.BskyAgent {
+  const agent = new atproto.BskyAgent({ service: BSKY_API });
 
-  const user = useState<AtpSessionData>("user").value;
+  const user = useState<atproto.AtpSessionData>("user").value;
 
   if (user) {
     agent.session = user;
@@ -28,7 +28,7 @@ export async function login(
 ): Promise<{ error: any; success: boolean }> {
   const agent = newAgent();
   let success: boolean;
-  let data: AtpSessionData;
+  let data: atproto.AtpSessionData;
 
   try {
     const result = await agent.login({ identifier, password });
@@ -42,14 +42,14 @@ export async function login(
     return { success, error: "Invalid identifier or password" };
   }
 
-  useCookie<AtpSessionData>(COOKIE_NAME).value = data;
+  useCookie<atproto.AtpSessionData>(COOKIE_NAME).value = data;
   useState("user").value = data;
 
   return { success, error: null };
 }
 
-export async function fetchUser(): Promise<AtpSessionData | null> {
-  const cookie = useCookie<AtpSessionData | null>(COOKIE_NAME, {
+export async function fetchUser(): Promise<atproto.AtpSessionData | null> {
+  const cookie = useCookie<atproto.AtpSessionData | null>(COOKIE_NAME, {
     expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 30),
   });
 
@@ -70,6 +70,7 @@ export async function fetchUser(): Promise<AtpSessionData | null> {
       case "expired":
         cookie.value = null;
         useState("user").value = null;
+        break;
       default:
         break;
     }

--- a/web/info/src/lib/atp.ts
+++ b/web/info/src/lib/atp.ts
@@ -2,12 +2,12 @@ import { writable } from 'svelte/store';
 
 import { ATP_API, ATP_SESSION_COOKIE } from '$lib/constants';
 
-import { BskyAgent } from '@atproto/api';
+import * as atproto from '@atproto/api';
 
 import type { AtpSessionData, AtpSessionEvent } from '@atproto/api';
 
 const session = writable<AtpSessionData | null>(null),
-  agent = writable<BskyAgent | null>(null);
+  agent = writable<atproto.BskyAgent | null>(null);
 
 const setupSession = () => {
   let session: AtpSessionData | null = null;
@@ -70,7 +70,7 @@ const setupAgent = () => {
     }
   };
 
-  return new BskyAgent({ service: ATP_API, persistSession: persistSessionWith });
+  return new atproto.BskyAgent({ service: ATP_API, persistSession: persistSessionWith });
 };
 
 export { agent, session, setupAgent, setupSession };


### PR DESCRIPTION
This fixes the imports of `@atproto/api` because its dist files are in CommonJS while our Nuxt server is a `.mjs` module.

See related issue: https://github.com/bluesky-social/atproto/issues/910