### PR TITLE
Show correct user avatar in nav

### DIFF
--- a/web/admin/components/core/nav.vue
+++ b/web/admin/components/core/nav.vue
@@ -1,5 +1,9 @@
 <script setup>
-import { logout } from "~/lib/auth";
+import { logout, newAgent } from "~/lib/auth";
+
+const user = await useUser();
+const agent = newAgent();
+const profile = await agent.getProfile({ actor: user.value.did });
 </script>
 
 <template>
@@ -19,7 +23,7 @@ import { logout } from "~/lib/auth";
     <div class="ml-auto flex items-center gap-2">
       <img
         class="rounded-full"
-        src="https://cdn.bsky.social/imgproxy/eJpUb3-QB55Yq73mMNdtgroGSVAcbjFB_55EgaNb6HE/rs:fill:1000:1000:1:0/plain/bafkreibhdnzijesikan6bpvmobvhunhtwyvthna32yyyhniosea2hkwa5e@jpeg"
+        :src="profile.data.avatar"
         height="32"
         width="32"
         alt=""


### PR DESCRIPTION
This fixes that the avatar in the admin navbar is always my avatar.

## Screenshots

(Please pretend that there is your avatar in the right one.)

| Before | After |
| --- | --- |
| ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/bcd891b8-6c36-4c73-80e7-a90bfd49ddcc) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/713e05c4-c040-4d62-9598-2d11630c131e) |

