### PR TITLE
Show number of accounts in queue

### DIFF
--- a/web/admin/components/user-card.vue
+++ b/web/admin/components/user-card.vue
@@ -2,7 +2,7 @@
 import { ProfileViewDetailed } from "@atproto/api/dist/client/types/app/bsky/actor/defs";
 import { newAgent } from "~/lib/auth";
 
-const props = defineProps<{ did: string; loading: boolean }>();
+const props = defineProps<{ did: string; loading: boolean; pending: number }>();
 defineEmits(["accept", "reject"]);
 
 const agent = newAgent();
@@ -24,7 +24,7 @@ await loadProfile();
 
 <template>
   <shared-card v-if="data">
-    <div class="flex gap-3 pt-2 mb-5">
+    <div class="flex items-center gap-3 pt-2 mb-5">
       <button
         class="px-3 py-2 bg-blue-400 dark:bg-blue-500 rounded-lg"
         :disabled="loading"
@@ -39,6 +39,12 @@ await loadProfile();
       >
         Reject
       </button>
+
+      <span
+        v-if="pending > 0"
+        class="ml-auto text-sm text-gray-600 dark:text-gray-400"
+        >and {{ pending }} more...</span
+      >
     </div>
 
     <div class="flex gap-3 items-center">

--- a/web/admin/pages/index.vue
+++ b/web/admin/pages/index.vue
@@ -6,11 +6,13 @@ import {
 } from "../../proto/bff/v1/moderation_service_pb";
 
 const api = await useAPI();
+const pending = ref(0);
 const actor = ref<Actor>();
 const loading = ref(false);
 
 const nextActor = async () => {
   const queue = await api.listActors({ filterStatus: ActorStatus.PENDING });
+  pending.value = queue.actors.length - 1;
   actor.value = queue.actors[0];
 };
 
@@ -38,6 +40,7 @@ await nextActor();
       v-if="actor"
       :did="actor.did"
       :loading="loading"
+      :pending="pending"
       @accept="accept"
       @reject="reject"
     />


### PR DESCRIPTION
This adds a counter to show the number of accounts remaining in the queue (excluding the current one).

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/ea4bd99b-221a-478d-849e-d911ae265930) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/25a30466-785e-47df-8e93-28d9311dbe38) |
