### PR TITLE
Add audit events to profile page

### DIFF
--- a/web/admin/components/action.vue
+++ b/web/admin/components/action.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import {
+  ApprovalQueueAction,
+  AuditEvent,
+  CommentAuditPayload,
+  ProcessApprovalQueueAuditPayload,
+} from "../../proto/bff/v1/moderation_service_pb";
+
+const props = defineProps<{
+  action: AuditEvent;
+}>();
+
+const payload = computed(() => {
+  if (!props.action.payload) return;
+
+  const { typeUrl, value } = props.action.payload;
+
+  switch (typeUrl.replace(/^type.googleapis.com\//, "")) {
+    case "bff.v1.ProcessApprovalQueueAuditPayload":
+      return ProcessApprovalQueueAuditPayload.fromBinary(value);
+    case "bff.v1.CommentAuditPayload":
+      return CommentAuditPayload.fromBinary(value);
+  }
+});
+
+const type = computed(() => {
+  const data = payload.value;
+
+  if (data instanceof ProcessApprovalQueueAuditPayload) {
+    return data.action === ApprovalQueueAction.APPROVE
+      ? "queue_approval"
+      : "queue_rejection";
+  } else if (data instanceof CommentAuditPayload) {
+    return "comment";
+  }
+});
+
+const actionText = computed(() => {
+  switch (type.value) {
+    case "queue_approval":
+      return "approved this user.";
+    case "queue_rejection":
+      return "rejected this user";
+    case "comment":
+      return "commented.";
+  }
+});
+
+const comment = computed(() => {
+  const data = payload.value;
+
+  if (data instanceof CommentAuditPayload) {
+    return data.comment;
+  }
+});
+</script>
+
+<template>
+  <div class="flex items-start my-4">
+    <div
+      class="bg-gray-700 rounded-full flex items-center justify-center h-6 w-6 mr-3"
+    >
+      <icon-check v-if="type === 'queue_approval'" class="text-green-500" />
+      <icon-cross v-else-if="type === 'queue_rejection'" class="text-red-500" />
+      <icon-comment v-else-if="type === 'comment'" class="text-gray-300" />
+    </div>
+    <div class="flex-1">
+      <div class="flex items-center gap-1">
+        <user-link :did="action.actorDid" />
+        {{ actionText }}
+        <span class="text-gray-600 dark:text-gray-400 text-xs">{{
+          action.createdAt?.toDate().toLocaleDateString("en", {
+            day: "numeric",
+            month: "short",
+            year: "numeric",
+            hour: "2-digit",
+            minute: "2-digit",
+          })
+        }}</span>
+      </div>
+      <shared-card v-if="comment" no-padding class="text-sm px-3 py-2 mt-2">
+        {{ comment }}
+      </shared-card>
+    </div>
+  </div>
+</template>

--- a/web/admin/components/icon/comment.vue
+++ b/web/admin/components/icon/comment.vue
@@ -1,0 +1,18 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="feather feather-message-square"
+  >
+    <path
+      d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"
+    ></path>
+  </svg>
+</template>

--- a/web/admin/components/icon/follow.vue
+++ b/web/admin/components/icon/follow.vue
@@ -1,0 +1,19 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="feather feather-user-plus"
+  >
+    <path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+    <circle cx="8.5" cy="7" r="4"></circle>
+    <line x1="20" y1="8" x2="20" y2="14"></line>
+    <line x1="23" y1="11" x2="17" y2="11"></line>
+  </svg>
+</template>

--- a/web/admin/components/shared/card.vue
+++ b/web/admin/components/shared/card.vue
@@ -1,5 +1,12 @@
+<script setup lang="ts">
+defineProps<{ noPadding?: boolean }>();
+</script>
+
 <template>
-  <div class="border border-gray-300 dark:border-gray-700 rounded-lg px-4 py-3">
+  <div
+    class="border border-gray-300 dark:border-gray-700 rounded-lg"
+    :class="{ 'px-4 py-3': !noPadding }"
+  >
     <slot />
   </div>
 </template>

--- a/web/admin/components/shared/comment-box.vue
+++ b/web/admin/components/shared/comment-box.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+const $emit = defineEmits<{ (event: "comment", comment: string): void }>();
+
+const text = ref("");
+
+function comment() {
+  $emit("comment", text.value);
+  text.value = "";
+}
+</script>
+
+<template>
+  <div class="flex gap-2 mt-5 mb-24 text-sm">
+    <input
+      v-model="text"
+      class="flex-1 py-1 px-2 rounded-lg border border-gray-300 text-black"
+      placeholder="Type your comment..."
+      type="text"
+    />
+    <button
+      :disabled="text.trim().length === 0"
+      class="px-3 py-1 bg-blue-400 dark:bg-blue-600 rounded-lg hover:bg-blue-500 dark:hover:bg-blue-700 disabled:bg-blue-300 disabled:dark:bg-blue-500 disabled:cursor-not-allowed"
+      @click="comment"
+    >
+      Comment
+    </button>
+  </div>
+</template>

--- a/web/admin/components/user-card.vue
+++ b/web/admin/components/user-card.vue
@@ -5,8 +5,8 @@ import { ActorStatus } from "../../proto/bff/v1/moderation_service_pb";
 
 const props = defineProps<{
   did: string;
-  loading: boolean;
-  pending: number;
+  loading?: boolean;
+  pending?: number;
   variant: "queue" | "profile";
 }>();
 defineEmits(["accept", "reject"]);
@@ -38,7 +38,10 @@ await loadProfile();
 
 <template>
   <shared-card v-if="data" :class="{ loading }">
-    <div v-if="variant === 'queue'" class="flex items-center gap-3 pt-2 mb-5">
+    <div
+      v-if="variant === 'queue' && status === ActorStatus.PENDING"
+      class="flex items-center gap-3 pt-2 mb-5"
+    >
       <button
         class="px-3 py-2 bg-blue-400 dark:bg-blue-600 rounded-lg hover:bg-blue-500 dark:hover:bg-blue-700 disabled:bg-blue-300 disabled:dark:bg-blue-500 disabled:cursor-not-allowed"
         :disabled="loading"

--- a/web/admin/components/user-link.vue
+++ b/web/admin/components/user-link.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { newAgent } from "~/lib/auth";
+
+const props = defineProps<{ did: string }>();
+const agent = newAgent();
+
+const { data } = await agent.getProfile({
+  actor: props.did,
+});
+</script>
+
+<template>
+  <nuxt-link
+    class="flex items-center underline hover:no-underline"
+    :href="`/users/${data.did}`"
+  >
+    <img
+      class="rounded-full mr-1"
+      :src="data.avatar"
+      height="20"
+      width="20"
+      alt=""
+    />
+    {{ data.handle }}
+  </nuxt-link>
+</template>

--- a/web/admin/composables/useAPI.ts
+++ b/web/admin/composables/useAPI.ts
@@ -1,6 +1,11 @@
 import { createPromiseClient } from "@bufbuild/connect";
 import { createConnectTransport } from "@bufbuild/connect-web";
 import { ModerationService } from "../../proto/bff/v1/moderation_service_connectweb";
+import { createRegistry } from "@bufbuild/protobuf";
+import {
+  CommentAuditPayload,
+  ProcessApprovalQueueAuditPayload,
+} from "../../proto/bff/v1/moderation_service_pb";
 
 export default async function () {
   const user = await useUser();
@@ -14,6 +19,13 @@ export default async function () {
       );
 
       return globalThis.fetch(input, { ...data });
+    },
+
+    jsonOptions: {
+      typeRegistry: createRegistry(
+        ProcessApprovalQueueAuditPayload,
+        CommentAuditPayload
+      ),
     },
   });
 

--- a/web/admin/pages/users/[did].vue
+++ b/web/admin/pages/users/[did].vue
@@ -1,12 +1,45 @@
-<script setup>
+<script setup lang="ts">
 import { newAgent } from "~/lib/auth";
+import { AuditEvent } from "../../../proto/bff/v1/moderation_service_pb";
+
+const api = await useAPI();
 
 const agent = newAgent();
-const { data } = await agent.getProfile({ actor: useRoute().params.did });
+const { data: subject } = await agent.getProfile({
+  actor: String(useRoute().params.did),
+});
+
+const auditEvents: Ref<AuditEvent[]> = ref([]);
+
+async function loadEvents() {
+  const response = await api.listAuditEvents({ subjectDid: subject.did });
+  auditEvents.value = response.auditEvents;
+}
+
+async function comment(comment: string) {
+  await api.createCommentAuditEvent({
+    subjectDid: subject.did,
+    comment,
+  });
+  await loadEvents();
+}
+
+await loadEvents();
 </script>
 
 <template>
   <div>
-    <user-card class="mb-5" :did="data.did" variant="profile" />
+    <user-card class="mb-5" :did="subject.did" variant="profile" />
+    <h2 class="font-bold mb-3">Comments</h2>
+    <action
+      v-for="action in auditEvents.sort(
+        (a, b) =>
+          (a.createdAt?.toDate().getTime() || 0) -
+          (b.createdAt?.toDate().getTime() || 0)
+      )"
+      :key="action.id"
+      :action="action"
+    />
+    <shared-comment-box @comment="comment" />
   </div>
 </template>


### PR DESCRIPTION
This adds audit events (i.e. approvals/rejections and comments) to profile pages.

## Screenshots

![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/8713d025-3dc9-496e-a427-ac5cfe70434a)

## How to test

1. Look for a recently approved user in the search
2. See that there is an approval audit event

For comments, change `baseUrl` in `web/admin/composables/useAPI.ts` to `http://localhost:1337` (i.e. to test locally):

1. Go to a user
2. Type a comment
3. Click on **Comment**
4. See that the comment was submitted