### PR TITLE
Make admin API URL configurable in environment

### DIFF
--- a/web/admin/composables/useAPI.ts
+++ b/web/admin/composables/useAPI.ts
@@ -3,9 +3,10 @@ import { createConnectTransport } from "@bufbuild/connect-web";
 import { ModerationService } from "../../proto/bff/v1/moderation_service_connectweb";
 
 export default async function () {
+  const { apiUrl } = useRuntimeConfig().public;
   const user = await useUser();
   const transport = createConnectTransport({
-    baseUrl: "https://feed.furryli.st",
+    baseUrl: apiUrl,
 
     fetch(input, data = {}) {
       (data.headers as Headers).set(

--- a/web/admin/nuxt.config.ts
+++ b/web/admin/nuxt.config.ts
@@ -3,4 +3,9 @@ export default defineNuxtConfig({
   modules: ["@nuxtjs/tailwindcss"],
   devtools: { enabled: true },
   ssr: false,
+  runtimeConfig: {
+    public: {
+      apiUrl: process.env.ADMIN_API_URL || "https://feed.furryli.st",
+    },
+  },
 });


### PR DESCRIPTION
This makes the API URL of the admin panel configurable with an environment variable. It defaults to the production URL, so there’s no need for changes in the deployment.