### PR TITLE
Fix logins expire after closing tab

### DIFF
--- a/web/admin/lib/auth.ts
+++ b/web/admin/lib/auth.ts
@@ -20,6 +20,7 @@ export async function logout() {
   agent.session = undefined;
   useCookie<null>(COOKIE_NAME, { expires: new Date() }).value = null;
   useState("user").value = null;
+  window.location.reload();
 }
 
 export async function login(
@@ -42,7 +43,9 @@ export async function login(
     return { success, error: "Invalid identifier or password" };
   }
 
-  useCookie<atproto.AtpSessionData>(COOKIE_NAME).value = data;
+  useCookie<atproto.AtpSessionData>(COOKIE_NAME, {
+    expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 30),
+  }).value = data;
   useState("user").value = data;
 
   return { success, error: null };


### PR DESCRIPTION
This fixes a bug where the login of a user expires after closing the tab because the cookie is set as session cookie (due to a lack of expiry date).

## How to test

1. Login to the app
2. Close the tab
3. Open the app again
4. See that you are still logged in