### PR TITLE
Restyle queue actions

### DIFF
--- a/web/admin/components/user-queue-actions.vue
+++ b/web/admin/components/user-queue-actions.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { ApprovalQueueAction } from "../../proto/bff/v1/moderation_service_pb";
+
+const props = defineProps<{
+  did: string;
+  handle: string;
+  pending?: number;
+}>();
+const $emit = defineEmits(["loading", "next"]);
+
+const loading = ref(false);
+
+const accept = () => process(props.did, ApprovalQueueAction.APPROVE);
+const reject = () => process(props.did, ApprovalQueueAction.REJECT);
+
+const api = await useAPI();
+async function process(did: string, action: ApprovalQueueAction) {
+  loading.value = true;
+  $emit("loading");
+  await api.processApprovalQueue({
+    did,
+    action,
+  });
+  $emit("next");
+  loading.value = false;
+}
+</script>
+
+<template>
+  <div
+    class="mb-3 rounded-lg bg-orange-400 text-black px-3 py-1 flex items-baseline text-sm"
+  >
+    {{ handle }} requested to be on the feed.
+    <span class="ml-auto">
+      <span v-if="pending" class="text-xs text-gray-700 mx-1">
+        ({{ pending }} more...)
+      </span>
+      <button
+        class="py-0.5 px-2 mr-1 text-white bg-blue-400 dark:bg-blue-600 rounded-lg hover:bg-blue-500 dark:hover:bg-blue-700 disabled:bg-blue-300 disabled:dark:bg-blue-500 disabled:cursor-not-allowed"
+        :disabled="loading"
+        @click="accept"
+      >
+        Accept
+      </button>
+
+      <button
+        class="py-0.5 px-2 bg-red-500 dark:bg-red-600 hover:bg-red-600 dark:hover:bg-red-700 disabled:bg-red-400 disabled:dark:bg-red-500 rounded-lg disabled:cursor-not-allowed"
+        :disabled="loading"
+        @click="reject"
+      >
+        Reject
+      </button>
+    </span>
+  </div>
+</template>

--- a/web/admin/pages/index.vue
+++ b/web/admin/pages/index.vue
@@ -1,33 +1,14 @@
 <script lang="ts" setup>
-import {
-  Actor,
-  ActorStatus,
-  ApprovalQueueAction,
-} from "../../proto/bff/v1/moderation_service_pb";
+import { Actor, ActorStatus } from "../../proto/bff/v1/moderation_service_pb";
 
 const api = await useAPI();
 const pending = ref(0);
 const actor = ref<Actor>();
-const loading = ref(false);
 
 const nextActor = async () => {
   const queue = await api.listActors({ filterStatus: ActorStatus.PENDING });
   pending.value = queue.actors.length - 1;
   actor.value = queue.actors[0];
-};
-
-const accept = () =>
-  process(actor.value?.did as string, ApprovalQueueAction.APPROVE);
-const reject = () =>
-  process(actor.value?.did as string, ApprovalQueueAction.REJECT);
-const process = async (did: string, action: ApprovalQueueAction) => {
-  loading.value = true;
-  await api.processApprovalQueue({
-    did,
-    action,
-  });
-  await nextActor();
-  loading.value = false;
 };
 
 await nextActor();
@@ -37,11 +18,9 @@ await nextActor();
   <user-card
     v-if="actor"
     :did="actor.did"
-    :loading="loading"
     :pending="pending"
     variant="queue"
-    @accept="accept"
-    @reject="reject"
+    @next="nextActor"
   />
   <shared-card v-else> No user is in the queue. </shared-card>
 </template>


### PR DESCRIPTION
This restyles the queue actions (approve, reject) and adds them to the profile pages.

## Screenshots

| Page | Before | After |
| --- | --- | --- |
| Queue | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/20c7f825-aa6e-45cc-b85f-a8a94b1b4a5d) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/718e878b-b746-4252-925e-0eb58ff3da7f) |
| Profile | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/d8271933-0380-4c72-a77e-bfcb3083e3f2) |  ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/fbbdc146-3e46-46b5-8d5a-2d50e601fc5f) |