### PR TITLE
Refresh after accepting/rejecting actor on profile

### DIFF
--- a/web/admin/pages/users/[did].vue
+++ b/web/admin/pages/users/[did].vue
@@ -1,35 +1,52 @@
 <script setup lang="ts">
 import { newAgent } from "~/lib/auth";
 import { AuditEvent } from "../../../proto/bff/v1/moderation_service_pb";
+import { ProfileViewDetailed } from "@atproto/api/dist/client/types/app/bsky/actor/defs";
 
 const api = await useAPI();
 
+const subject = ref() as Ref<ProfileViewDetailed>;
 const agent = newAgent();
-const { data: subject } = await agent.getProfile({
-  actor: String(useRoute().params.did),
-});
+async function loadProfile() {
+  const { data } = await agent.getProfile({
+    actor: String(useRoute().params.did),
+  });
+  subject.value = data;
+}
 
 const auditEvents: Ref<AuditEvent[]> = ref([]);
 
 async function loadEvents() {
-  const response = await api.listAuditEvents({ filterSubjectDid: subject.did });
+  const response = await api.listAuditEvents({
+    filterSubjectDid: subject.value.did,
+  });
   auditEvents.value = response.auditEvents;
 }
 
 async function comment(comment: string) {
   await api.createCommentAuditEvent({
-    subjectDid: subject.did,
+    subjectDid: subject.value.did,
     comment,
   });
   await loadEvents();
 }
 
-await loadEvents();
+async function refresh() {
+  await loadProfile();
+  await loadEvents();
+}
+
+await refresh();
 </script>
 
 <template>
   <div>
-    <user-card class="mb-5" :did="subject.did" variant="profile" />
+    <user-card
+      class="mb-5"
+      :did="subject.did"
+      variant="profile"
+      @next="refresh"
+    />
     <h2 class="font-bold mb-3">Comments</h2>
     <action
       v-for="action in auditEvents.sort(


### PR DESCRIPTION
This improves the UX on the profile page when accepting or rejecting the actor by refreshing the comments and profile after an action was performed.

## How to test

1. Go to an unapproved actor’s profile page
2. Approve or reject them (remember: approving means you'll follow them)
3. See that the comments are updated and now include your approval/rejection