### PR TITLE
Fix queue actions placing on mobile

### DIFF
--- a/web/admin/components/user-queue-actions.vue
+++ b/web/admin/components/user-queue-actions.vue
@@ -28,15 +28,17 @@ async function process(did: string, action: ApprovalQueueAction) {
 
 <template>
   <div
-    class="mb-3 rounded-lg bg-orange-400 text-black px-3 py-1 flex items-baseline text-sm"
+    class="mb-3 rounded-lg bg-orange-400 text-black px-3 py-1 flex items-baseline text-sm max-md:flex-col"
   >
-    {{ handle }} requested to be on the feed.
-    <span class="ml-auto">
+    <span class="max-md:order-1"
+      >{{ handle }} requested to be on the feed.</span
+    >
+    <span class="md:ml-auto max-md:w-full flex items-baseline">
       <span v-if="pending" class="text-xs text-gray-700 mx-1">
         ({{ pending }} more...)
       </span>
       <button
-        class="py-0.5 px-2 mr-1 text-white bg-blue-400 dark:bg-blue-600 rounded-lg hover:bg-blue-500 dark:hover:bg-blue-700 disabled:bg-blue-300 disabled:dark:bg-blue-500 disabled:cursor-not-allowed"
+        class="py-0.5 px-2 max-md:ml-auto mr-1 text-white bg-blue-400 dark:bg-blue-600 rounded-lg hover:bg-blue-500 dark:hover:bg-blue-700 disabled:bg-blue-300 disabled:dark:bg-blue-500 disabled:cursor-not-allowed"
         :disabled="loading"
         @click="accept"
       >


### PR DESCRIPTION
This fixes the placement of the queue actions on mobile, so the buttons don’t shift.

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/85ed8fe9-2a8c-4afa-929d-081e67037969) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/6e581817-70b4-4ede-afb1-b009fe9bba5c) |