### PR TITLE
Move search bar out of mobile nav

### DIFF
--- a/web/admin/components/core/nav.vue
+++ b/web/admin/components/core/nav.vue
@@ -1,7 +1,17 @@
 <script setup>
+import { search } from "~/lib/search";
 import { logout } from "~/lib/auth";
 
 const profile = await useProfile();
+const showSearch = ref(false);
+
+const term = ref("");
+async function doSearch() {
+  if (await search(term.value)) {
+    term.value = "";
+    showSearch.value = false;
+  }
+}
 </script>
 
 <template>
@@ -19,7 +29,7 @@ const profile = await useProfile();
     </nuxt-link>
     <h1 class="text-xl font-bold">Admin</h1>
     <div class="ml-auto flex items-center gap-2">
-      <shared-search />
+      <shared-search @toggle-search="showSearch = !showSearch" />
       <img
         class="rounded-full"
         :src="profile.avatar"
@@ -35,4 +45,22 @@ const profile = await useProfile();
       </button>
     </div>
   </nav>
+  <div
+    v-if="showSearch"
+    class="flex text-sm px-4 py-3 mb-5 border border-gray-300 dark:border-gray-700 rounded-lg"
+  >
+    <input
+      v-model="term"
+      class="py-1 px-2 w-full rounded-l-lg border border-gray-300 text-black"
+      type="text"
+      placeholder="User handle or did"
+      @keydown="$event.key === 'Enter' ? doSearch() : null"
+    />
+    <button
+      class="text-white bg-blue-400 dark:bg-blue-500 rounded-r-lg px-1 py-1"
+      @click="doSearch"
+    >
+      <icon-search />
+    </button>
+  </div>
 </template>

--- a/web/admin/components/shared/search.vue
+++ b/web/admin/components/shared/search.vue
@@ -1,34 +1,35 @@
 <script setup>
-import { newAgent } from "~/lib/auth";
+import { search } from "~/lib/search";
+
+const $emit = defineEmits(["toggleSearch"]);
 
 const term = ref();
 
-const search = async () => {
-  const agent = newAgent();
-  const { data, success } = await agent
-    .getProfile({ actor: term.value })
-    .catch(() => ({ success: false }));
-  if (!success) {
-    alert("Could not find user. Please check handle or did, and try again.");
-    return;
+async function doSearch() {
+  if (await search(term.value)) {
+    term.value = "";
   }
-  useRouter().push(`/users/${data.did}`);
-  term.value = "";
-};
+}
 </script>
 
 <template>
-  <div class="flex">
+  <div class="flex text-sm">
     <input
       v-model="term"
-      class="py-1 px-2 rounded-l-lg border border-gray-300 text-black"
+      class="py-1 px-2 rounded-l-lg border border-gray-300 text-black max-md:hidden"
       type="text"
       placeholder="User handle or did"
-      @keydown="$event.key === 'Enter' ? search() : null"
+      @keydown="$event.key === 'Enter' ? doSearch() : null"
     />
     <button
-      class="text-white bg-blue-400 dark:bg-blue-500 rounded-r-lg px-1"
-      @click="search"
+      class="text-white bg-blue-400 dark:bg-blue-500 rounded-r-lg max-md:hidden px-1 py-1"
+      @click="doSearch"
+    >
+      <icon-search />
+    </button>
+    <button
+      class="text-white bg-blue-400 dark:bg-blue-500 rounded-lg md:hidden px-1 py-1"
+      @click="$emit('toggleSearch')"
     >
       <icon-search />
     </button>

--- a/web/admin/lib/search.ts
+++ b/web/admin/lib/search.ts
@@ -1,0 +1,16 @@
+import { newAgent } from "./auth";
+
+export async function search(term: string) {
+  const agent = newAgent();
+  const { data, success } = await agent
+    .getProfile({ actor: term })
+    .catch(() => ({ success: false, data: undefined }));
+
+  if (!success) {
+    alert("Could not find user. Please check handle or did, and try again.");
+    return;
+  }
+
+  useRouter().push(`/users/${data?.did}`);
+  return data?.did;
+}


### PR DESCRIPTION
This moves the search bar out of the mobile nav and leaves a button to toggle the search.

There are no changes to the desktop search.

## Screenshots

| Before | After (closed) | After (open) |
| --- | --- | --- |
| ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/9dbd6213-4922-4760-b970-fdc112b9af06) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/1a3ed4a3-fac8-4aab-a090-01c70a25c805) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/1bc0db61-a331-47d3-80a3-355247f77a6e)