### PR TITLE
Add designs for other audit entries

### DIFF
--- a/web/admin/components/action.vue
+++ b/web/admin/components/action.vue
@@ -80,13 +80,13 @@ const comment = computed(() => {
     <div
       class="bg-gray-800 rounded-full flex items-center justify-center h-7 w-7 mr-3"
     >
-      <icon-user-plus v-if="type === 'queue_approval'" class="text-gray-300" />
+      <icon-user-plus v-if="type === 'queue_approval'" class="text-gray-200" />
       <icon-user-minus
         v-else-if="type === 'queue_rejection' || type === 'unapprove'"
-        class="text-gray-300"
+        class="text-gray-200"
       />
       <icon-slash v-else-if="type === 'ban'" class="text-red-700" />
-      <icon-comment v-else-if="type === 'comment'" class="text-gray-300" />
+      <icon-comment v-else-if="type === 'comment'" class="text-gray-200" />
     </div>
     <div class="flex-1">
       <div class="flex items-center gap-1">

--- a/web/admin/components/action.vue
+++ b/web/admin/components/action.vue
@@ -2,8 +2,10 @@
 import {
   ApprovalQueueAction,
   AuditEvent,
+  BanActorAuditPayload,
   CommentAuditPayload,
   ProcessApprovalQueueAuditPayload,
+  UnapproveActorAuditPayload,
 } from "../../proto/bff/v1/moderation_service_pb";
 
 const props = defineProps<{
@@ -20,6 +22,12 @@ const payload = computed(() => {
       return ProcessApprovalQueueAuditPayload.fromBinary(value);
     case "bff.v1.CommentAuditPayload":
       return CommentAuditPayload.fromBinary(value);
+    case "bff.v1.UnapproveActorAuditPayload":
+      return UnapproveActorAuditPayload.fromBinary(value);
+    case "bff.v1.BanActorAuditPayload":
+      return BanActorAuditPayload.fromBinary(value);
+    default:
+      console.warn(`Missing payload decoding: ${typeUrl}`);
   }
 });
 
@@ -32,6 +40,10 @@ const type = computed(() => {
       : "queue_rejection";
   } else if (data instanceof CommentAuditPayload) {
     return "comment";
+  } else if (data instanceof UnapproveActorAuditPayload) {
+    return "unapprove";
+  } else if (data instanceof BanActorAuditPayload) {
+    return "ban";
   }
 });
 
@@ -43,6 +55,10 @@ const actionText = computed(() => {
       return "rejected this user";
     case "comment":
       return "commented.";
+    case "unapprove":
+      return "unapproved this user.";
+    case "ban":
+      return "banned this user.";
   }
 });
 
@@ -51,6 +67,10 @@ const comment = computed(() => {
 
   if (data instanceof CommentAuditPayload) {
     return data.comment;
+  } else if (data instanceof UnapproveActorAuditPayload) {
+    return data.reason;
+  } else if (data instanceof BanActorAuditPayload) {
+    return data.reason;
   }
 });
 </script>
@@ -58,10 +78,14 @@ const comment = computed(() => {
 <template>
   <div class="flex items-start my-4">
     <div
-      class="bg-gray-700 rounded-full flex items-center justify-center h-6 w-6 mr-3"
+      class="bg-gray-800 rounded-full flex items-center justify-center h-7 w-7 mr-3"
     >
-      <icon-check v-if="type === 'queue_approval'" class="text-green-500" />
-      <icon-cross v-else-if="type === 'queue_rejection'" class="text-red-500" />
+      <icon-user-plus v-if="type === 'queue_approval'" class="text-gray-300" />
+      <icon-user-minus
+        v-else-if="type === 'queue_rejection' || type === 'unapprove'"
+        class="text-gray-300"
+      />
+      <icon-slash v-else-if="type === 'ban'" class="text-red-700" />
       <icon-comment v-else-if="type === 'comment'" class="text-gray-300" />
     </div>
     <div class="flex-1">

--- a/web/admin/components/action.vue
+++ b/web/admin/components/action.vue
@@ -85,7 +85,7 @@ const comment = computed(() => {
         v-else-if="type === 'queue_rejection' || type === 'unapprove'"
         class="text-gray-200"
       />
-      <icon-slash v-else-if="type === 'ban'" class="text-red-700" />
+      <icon-slash v-else-if="type === 'ban'" class="text-red-500" />
       <icon-comment v-else-if="type === 'comment'" class="text-gray-200" />
     </div>
     <div class="flex-1">

--- a/web/admin/components/icon/slash.vue
+++ b/web/admin/components/icon/slash.vue
@@ -6,13 +6,12 @@
     viewBox="0 0 24 24"
     fill="none"
     stroke="currentColor"
-    stroke-width="2.5"
+    stroke-width="2"
     stroke-linecap="round"
     stroke-linejoin="round"
-    class="feather feather-message-square"
+    class="feather feather-slash"
   >
-    <path
-      d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"
-    ></path>
+    <circle cx="12" cy="12" r="10"></circle>
+    <line x1="4.93" y1="4.93" x2="19.07" y2="19.07"></line>
   </svg>
 </template>

--- a/web/admin/components/icon/user-minus.vue
+++ b/web/admin/components/icon/user-minus.vue
@@ -9,10 +9,10 @@
     stroke-width="2.5"
     stroke-linecap="round"
     stroke-linejoin="round"
-    class="feather feather-message-square"
+    class="feather feather-user-minus"
   >
-    <path
-      d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"
-    ></path>
+    <path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+    <circle cx="8.5" cy="7" r="4"></circle>
+    <line x1="23" y1="11" x2="17" y2="11"></line>
   </svg>
 </template>

--- a/web/admin/components/icon/user-plus.vue
+++ b/web/admin/components/icon/user-plus.vue
@@ -9,10 +9,11 @@
     stroke-width="2.5"
     stroke-linecap="round"
     stroke-linejoin="round"
-    class="feather feather-message-square"
+    class="feather feather-user-plus"
   >
-    <path
-      d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"
-    ></path>
+    <path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+    <circle cx="8.5" cy="7" r="4"></circle>
+    <line x1="20" y1="8" x2="20" y2="14"></line>
+    <line x1="23" y1="11" x2="17" y2="11"></line>
   </svg>
 </template>


### PR DESCRIPTION
This adds designs for the audit entries of unapproving and banning a user.

This also changes the icons, so all icons have a stroke width of 2.5px and only banning a user has the stroke color red now.

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/3558f542-d306-4e4e-864c-dce822f7c01d) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/919f6d4e-b98b-4770-8c23-922d9c580b15) |