### PR TITLE
Add status badge and unapprove/ban actions

### DIFF
--- a/web/admin/components/user-actions.vue
+++ b/web/admin/components/user-actions.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { ActorStatus } from "../../proto/bff/v1/moderation_service_pb";
+
+const props = defineProps<{ did: string; status: ActorStatus }>();
+const $emit = defineEmits(["update"]);
+const api = await useAPI();
+
+async function remove() {
+  if (!confirm("Are you sure to remove this user from the list?")) {
+    return;
+  }
+
+  const reason = prompt("Enter the reason for unapproving the user.");
+
+  if (!reason) {
+    alert("A reason is required to unapprove the user.");
+    return;
+  }
+
+  await api.unapproveActor({ actorDid: props.did, reason });
+  $emit("update");
+}
+
+async function ban() {
+  if (!confirm("Are you sure to ban this user from the list?")) {
+    return;
+  }
+
+  const reason = prompt("Enter the reason for banning the user.");
+
+  if (!reason) {
+    alert("A reason is required to ban the user.");
+    return;
+  }
+
+  await api.banActor({ actorDid: props.did, reason });
+  $emit("update");
+}
+</script>
+
+<template>
+  <div class="mb-3 flex items-center text-sm gap-2">
+    <span>
+      <user-status-badge :status="status" />
+    </span>
+    <span class="ml-auto">&nbsp;</span>
+    <span v-if="props.status !== ActorStatus.BANNED">
+      <button class="rounded-lg py-1 px-2 bg-red-700 text-white" @click="ban">
+        Ban user
+      </button>
+    </span>
+    <span v-if="props.status === ActorStatus.APPROVED">
+      <button
+        class="rounded-lg py-1 px-2 bg-zinc-700 text-white"
+        @click="remove"
+      >
+        Remove from list
+      </button>
+    </span>
+  </div>
+</template>

--- a/web/admin/components/user-card.vue
+++ b/web/admin/components/user-card.vue
@@ -13,7 +13,7 @@ const $emit = defineEmits(["next"]);
 const api = await useAPI();
 const isArtist = ref(false);
 const loading = ref(false);
-const status = ref<ActorStatus | undefined>();
+const status = ref() as Ref<ActorStatus>;
 const data = ref<ProfileViewDetailed>();
 const loadProfile = async () => {
   const result = await getProfile(props.did);
@@ -22,7 +22,7 @@ const loadProfile = async () => {
     .getActor({ did: result.data.did })
     .catch(() => ({ actor: undefined }));
   isArtist.value = Boolean(actor?.isArtist);
-  status.value = actor?.status;
+  status.value = actor?.status || ActorStatus.UNSPECIFIED;
 };
 
 async function next() {
@@ -50,6 +50,12 @@ await loadProfile();
       :pending="pending"
       @next="next"
       @loading="loading = true"
+    />
+    <user-actions
+      v-if="variant === 'profile'"
+      :did="data.did"
+      :status="status"
+      @update="next"
     />
 
     <div class="flex gap-3 items-center mb-5">

--- a/web/admin/components/user-status-badge.vue
+++ b/web/admin/components/user-status-badge.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import { ActorStatus } from "../../proto/bff/v1/moderation_service_pb";
+import { ACTOR_STATUS_LABELS } from "~/lib/constants";
+
+const props = defineProps<{ status: ActorStatus }>();
+
+const statusLabel = computed(() => ACTOR_STATUS_LABELS[props.status]);
+const background = computed(
+  () =>
+    ({
+      [ActorStatus.UNSPECIFIED]: "bg-gray-600 text-white",
+      [ActorStatus.PENDING]: "bg-orange-400 text-black",
+      [ActorStatus.APPROVED]: "bg-green-700 text-white",
+      [ActorStatus.BANNED]: "bg-red-700 text-white",
+      [ActorStatus.NONE]: "bg-zinc-700 text-white",
+    }[props.status])
+);
+</script>
+
+<template>
+  <span class="rounded-full py-0.5 px-2 bg-" :class="background">
+    {{ statusLabel }}
+  </span>
+</template>

--- a/web/admin/lib/constants.ts
+++ b/web/admin/lib/constants.ts
@@ -1,0 +1,9 @@
+import { ActorStatus } from "../../proto/bff/v1/moderation_service_pb";
+
+export const ACTOR_STATUS_LABELS = {
+  [ActorStatus.UNSPECIFIED]: "Unspecified",
+  [ActorStatus.PENDING]: "Pending",
+  [ActorStatus.APPROVED]: "Approved",
+  [ActorStatus.BANNED]: "Banned",
+  [ActorStatus.NONE]: "None",
+};


### PR DESCRIPTION
This adds a status badge and the unapprove and ban actions to the profile pages.

## Screenshots

| State | Before | After |
| --- | --- | --- |
| None | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/e75b5efc-ae61-408d-b455-33286cb22eb7) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/3d42eba4-5550-442b-baa6-21b94213fb68) |
| Pending | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/e40871cd-8490-4b38-9a16-b4b3dd98e269) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/27fdfd66-02e9-40f9-97c0-8d3d55134949) |
| Approved | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/92afd148-f282-4cb7-9c60-1513c8840b35) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/ea3dc7c4-9ed2-434d-84ed-378be482785f) |
| Banned | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/095eaeac-8477-4ca8-8dea-cf228b20c3e5) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/ce91ca97-0525-4d1b-99f7-67b81baf9f62) |