### PR TITLE
Add simple audit log

### DIFF
--- a/web/admin/components/action.vue
+++ b/web/admin/components/action.vue
@@ -10,6 +10,7 @@ import {
 
 const props = defineProps<{
   action: AuditEvent;
+  lookupUser?: boolean;
 }>();
 
 const payload = computed(() => {
@@ -50,15 +51,15 @@ const type = computed(() => {
 const actionText = computed(() => {
   switch (type.value) {
     case "queue_approval":
-      return "approved this user.";
+      return props.lookupUser ? "approved" : "approved this user.";
     case "queue_rejection":
-      return "rejected this user";
+      return props.lookupUser ? "rejected" : "rejected this user.";
     case "comment":
-      return "commented.";
+      return props.lookupUser ? "commented on" : "commented.";
     case "unapprove":
-      return "unapproved this user.";
+      return props.lookupUser ? "unapproved" : "unapproved this user.";
     case "ban":
-      return "banned this user.";
+      return props.lookupUser ? "banned" : "banned this user.";
   }
 });
 
@@ -92,6 +93,7 @@ const comment = computed(() => {
       <div class="flex items-center gap-1">
         <user-link :did="action.actorDid" />
         {{ actionText }}
+        <user-link v-if="lookupUser" :did="action.subjectDid" />
         <span class="text-gray-600 dark:text-gray-400 text-xs">{{
           action.createdAt?.toDate().toLocaleDateString("en", {
             day: "numeric",

--- a/web/admin/components/user-card.vue
+++ b/web/admin/components/user-card.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { ProfileViewDetailed } from "@atproto/api/dist/client/types/app/bsky/actor/defs";
-import { newAgent } from "~/lib/auth";
 import { ActorStatus } from "../../proto/bff/v1/moderation_service_pb";
+import { getProfile } from "~/lib/cached-bsky";
 
 const props = defineProps<{
   did: string;
@@ -14,12 +14,9 @@ const api = await useAPI();
 const isArtist = ref(false);
 const loading = ref(false);
 const status = ref<ActorStatus | undefined>();
-const agent = newAgent();
 const data = ref<ProfileViewDetailed>();
 const loadProfile = async () => {
-  const result = await agent.getProfile({
-    actor: props.did,
-  });
+  const result = await getProfile(props.did);
   data.value = result.data;
   const { actor } = await api
     .getActor({ did: result.data.did })

--- a/web/admin/components/user-link.vue
+++ b/web/admin/components/user-link.vue
@@ -1,12 +1,9 @@
 <script setup lang="ts">
-import { newAgent } from "~/lib/auth";
+import { getProfile } from "~/lib/cached-bsky";
 
 const props = defineProps<{ did: string }>();
-const agent = newAgent();
 
-const { data } = await agent.getProfile({
-  actor: props.did,
-});
+const { data } = await getProfile(props.did);
 </script>
 
 <template>

--- a/web/admin/lib/cached-bsky.ts
+++ b/web/admin/lib/cached-bsky.ts
@@ -1,0 +1,19 @@
+import { AppBskyActorGetProfile } from "@atproto/api";
+import { newAgent } from "./auth";
+
+const cache: Map<string, Promise<AppBskyActorGetProfile.Response>> = new Map();
+
+export async function getProfile(
+  did: string
+): Promise<AppBskyActorGetProfile.Response> {
+  let profile = cache.get(did);
+  if (profile) {
+    return profile;
+  }
+
+  profile = newAgent().getProfile({ actor: did });
+
+  cache.set(did, profile);
+
+  return profile;
+}

--- a/web/admin/pages/audit-log.vue
+++ b/web/admin/pages/audit-log.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+const api = await useAPI();
+
+const { auditEvents } = await api.listAuditEvents({});
+</script>
+
+<template>
+  <div>
+    <h1 class="text-xl font-bold">Audit log</h1>
+    <p class="text-gray-600 dark:text-gray-400">
+      Showing the last 100 audit events.
+    </p>
+    <action
+      v-for="event in auditEvents"
+      :key="event.id"
+      :action="event"
+      lookup-user
+    />
+  </div>
+</template>


### PR DESCRIPTION
This adds a simple audit log. While&mdash;unlike discussed&mdash;this doesn't add a table, this is simpler to do as first iteration since we have the action component already for the profile pages.

This also adds caching for loading bsky profiles.

Closes #87

## Screenshot

![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/b59498ae-10a1-4293-8acb-52fc337b6549)
