### PR TITLE
Improve action icon background in light mode

### DIFF
--- a/web/admin/components/action.vue
+++ b/web/admin/components/action.vue
@@ -79,15 +79,21 @@ const comment = computed(() => {
 <template>
   <div class="flex items-start my-4">
     <div
-      class="bg-gray-800 rounded-full flex items-center justify-center h-7 w-7 mr-3"
+      class="bg-gray-200 dark:bg-gray-800 rounded-full flex items-center justify-center h-7 w-7 mr-3 flex-shrink-0"
     >
-      <icon-user-plus v-if="type === 'queue_approval'" class="text-gray-200" />
+      <icon-user-plus
+        v-if="type === 'queue_approval'"
+        class="text-gray-600 dark:text-gray-200"
+      />
       <icon-user-minus
         v-else-if="type === 'queue_rejection' || type === 'unapprove'"
-        class="text-gray-200"
+        class="text-gray-600 dark:text-gray-200"
       />
       <icon-slash v-else-if="type === 'ban'" class="text-red-500" />
-      <icon-comment v-else-if="type === 'comment'" class="text-gray-200" />
+      <icon-comment
+        v-else-if="type === 'comment'"
+        class="text-gray-600 dark:text-gray-200"
+      />
     </div>
     <div class="flex-1">
       <div class="flex max-md:flex-wrap items-center gap-1">


### PR DESCRIPTION
This improves the action icon background in light mode to make it look less contrast rich with the outside.

Relates to #93 

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/4d9c6ba4-44b8-426e-bdc0-42f75315516a) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/87ceac9c-a11e-4c4e-bfc2-6f37bc24bc29) |