### PR TITLE
Improve primary button color in light mode

### DIFF
--- a/web/admin/components/core/nav.vue
+++ b/web/admin/components/core/nav.vue
@@ -57,7 +57,7 @@ async function doSearch() {
       @keydown="$event.key === 'Enter' ? doSearch() : null"
     />
     <button
-      class="text-white bg-blue-400 dark:bg-blue-500 rounded-r-lg px-1 py-1"
+      class="text-white hover:bg-blue-600 dark:hover:bg-blue-700 disabled:bg-blue-300 disabled:dark:bg-blue-500 rounded-r-lg px-1 py-1"
       @click="doSearch"
     >
       <icon-search />

--- a/web/admin/components/shared/search.vue
+++ b/web/admin/components/shared/search.vue
@@ -22,13 +22,13 @@ async function doSearch() {
       @keydown="$event.key === 'Enter' ? doSearch() : null"
     />
     <button
-      class="text-white bg-blue-400 dark:bg-blue-500 rounded-r-lg max-md:hidden px-1 py-1"
+      class="text-white bg-blue-500 hover:bg-blue-600 dark:hover:bg-blue-700 disabled:bg-blue-300 disabled:dark:bg-blue-500 rounded-r-lg max-md:hidden px-1 py-1"
       @click="doSearch"
     >
       <icon-search />
     </button>
     <button
-      class="text-white bg-blue-400 dark:bg-blue-500 rounded-lg md:hidden px-1 py-1"
+      class="text-white bg-blue-500 hover:bg-blue-600 dark:hover:bg-blue-700 disabled:bg-blue-300 disabled:dark:bg-blue-500 rounded-lg md:hidden px-1 py-1"
       @click="$emit('toggleSearch')"
     >
       <icon-search />

--- a/web/admin/components/user-queue-actions.vue
+++ b/web/admin/components/user-queue-actions.vue
@@ -38,7 +38,7 @@ async function process(did: string, action: ApprovalQueueAction) {
         ({{ pending }} more...)
       </span>
       <button
-        class="py-0.5 px-2 max-md:ml-auto mr-1 text-white bg-blue-400 dark:bg-blue-600 rounded-lg hover:bg-blue-500 dark:hover:bg-blue-700 disabled:bg-blue-300 disabled:dark:bg-blue-500 disabled:cursor-not-allowed"
+        class="py-0.5 px-2 max-md:ml-auto mr-1 text-white bg-blue-500 dark:bg-blue-600 rounded-lg hover:bg-blue-600 dark:hover:bg-blue-700 disabled:bg-blue-300 disabled:dark:bg-blue-500 disabled:cursor-not-allowed"
         :disabled="loading"
         @click="accept"
       >


### PR DESCRIPTION
This adds a hover color to the navbar search button and changes the primary button color to a darker tone of blue in light mode.

Relates to #93 

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/32644ad9-1bb1-41c0-8ffa-5f84953fd548) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/b499a547-c39c-4ef7-9f75-51dd48bd391c) |