### PR TITLE
Remove "In list" status on profiles

### DIFF
--- a/web/admin/components/user-card.vue
+++ b/web/admin/components/user-card.vue
@@ -86,14 +86,6 @@ await loadProfile();
         </div>
         <div v-if="variant === 'profile'" class="meta">
           <span class="meta-item inline-flex items-center">
-            <icon-check
-              v-if="status === ActorStatus.APPROVED"
-              class="text-green-500"
-            />
-            <icon-cross v-else class="text-red-500" />
-            <span class="text-gray-600 dark:text-gray-400">In list</span>
-          </span>
-          <span class="meta-item inline-flex items-center">
             <icon-check v-if="isArtist" class="text-green-500" />
             <icon-cross v-else class="text-red-500" />
             <span class="text-gray-600 dark:text-gray-400">Artist</span>


### PR DESCRIPTION
This removes the **In list** status on profile because it’s redundant. The in list status is determined by the status shown on the top right of profiles, where the user is in the list (and the **In list** check mark would be shown) if their account is **Approved**.

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/d5d50652-6729-4d41-80be-60265c5fae70) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/f9071693-c867-4694-be8b-835cef41bf2a) |