### PR TITLE
Add action icon for force-approvals

### DIFF
--- a/web/admin/components/action.vue
+++ b/web/admin/components/action.vue
@@ -5,6 +5,7 @@ import {
   BanActorAuditPayload,
   CommentAuditPayload,
   CreateActorAuditPayload,
+  ForceApproveActorAuditPayload,
   ProcessApprovalQueueAuditPayload,
   UnapproveActorAuditPayload,
 } from "../../proto/bff/v1/moderation_service_pb";
@@ -30,6 +31,8 @@ const payload = computed(() => {
       return BanActorAuditPayload.fromBinary(value);
     case "bff.v1.CreateActorAuditPayload":
       return CreateActorAuditPayload.fromBinary(value);
+    case "bff.v1.ForceApproveActorAuditPayload":
+      return ForceApproveActorAuditPayload.fromBinary(value);
     default:
       console.warn(`Missing payload decoding: ${typeUrl}`);
   }
@@ -50,6 +53,8 @@ const type = computed(() => {
     return "ban";
   } else if (data instanceof CreateActorAuditPayload) {
     return "track";
+  } else if (data instanceof ForceApproveActorAuditPayload) {
+    return "force_approve";
   }
 });
 
@@ -69,6 +74,8 @@ const actionText = computed(() => {
       return props.lookupUser
         ? "started tracking"
         : "started tracking this user.";
+    case "force_approve":
+      return props.lookupUser ? "force-approved" : "force-approved this user.";
   }
 });
 
@@ -93,7 +100,7 @@ const comment = computed(() => {
       class="bg-gray-200 dark:bg-gray-800 rounded-full flex items-center justify-center h-7 w-7 mr-3 flex-shrink-0"
     >
       <icon-user-plus
-        v-if="type === 'queue_approval'"
+        v-if="type === 'queue_approval' || type === 'force_approve'"
         class="text-gray-600 dark:text-gray-200"
       />
       <icon-user-minus


### PR DESCRIPTION
This adds the action icon and UI text for the force-approval audit event.

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/44fdc70a-c53d-4ac2-9803-da01791d97ba) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/fad66d5f-9168-413a-bb98-33028ab0d31f) |