### PR TITLE
Limit actors loaded on queue (re)load

### DIFF
--- a/api/moderation.go
+++ b/api/moderation.go
@@ -277,6 +277,7 @@ func (m *ModerationServiceHandler) ListActors(ctx context.Context, req *connect.
 
 	actors, err := m.store.ListActors(ctx, store.ListActorsOpts{
 		FilterStatus: req.Msg.FilterStatus,
+		Limit:        req.Msg.Limit,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("listing actors: %w", err)

--- a/store/gen/candidate_actors.sql.go
+++ b/store/gen/candidate_actors.sql.go
@@ -193,14 +193,20 @@ SELECT did, created_at, is_artist, comment, status, roles, current_profile_commi
 FROM
     candidate_actors ca
 WHERE
-    ($1::actor_status IS NULL OR
-     ca.status = $1)
+    ($2::actor_status IS NULL OR
+     ca.status = $2)
 ORDER BY
     did
+LIMIT $1
 `
 
-func (q *Queries) ListCandidateActors(ctx context.Context, status NullActorStatus) ([]CandidateActor, error) {
-	rows, err := q.db.Query(ctx, listCandidateActors, status)
+type ListCandidateActorsParams struct {
+	Limit  int32
+	Status NullActorStatus
+}
+
+func (q *Queries) ListCandidateActors(ctx context.Context, arg ListCandidateActorsParams) ([]CandidateActor, error) {
+	rows, err := q.db.Query(ctx, listCandidateActors, arg.Limit, arg.Status)
 	if err != nil {
 		return nil, err
 	}

--- a/store/postgres.go
+++ b/store/postgres.go
@@ -160,6 +160,7 @@ func (s *PGXStore) TX(ctx context.Context) (*PGXTX, error) {
 
 type ListActorsOpts struct {
 	FilterStatus v1.ActorStatus
+	Limit        int32
 }
 
 func (s *PGXStore) ListActors(ctx context.Context, opts ListActorsOpts) (out []*v1.Actor, err error) {
@@ -178,7 +179,10 @@ func (s *PGXStore) ListActors(ctx context.Context, opts ListActorsOpts) (out []*
 		statusFilter.ActorStatus = status
 	}
 
-	actors, err := s.queries.ListCandidateActors(ctx, statusFilter)
+	actors, err := s.queries.ListCandidateActors(ctx, gen.ListCandidateActorsParams{
+		Status: statusFilter,
+		Limit:  opts.Limit,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("executing ListCandidateActors query: %w", err)
 	}

--- a/store/queries/candidate_actors.sql
+++ b/store/queries/candidate_actors.sql
@@ -6,7 +6,8 @@ WHERE
     (sqlc.narg(status)::actor_status IS NULL OR
      ca.status = @status)
 ORDER BY
-    did;
+    did
+LIMIT $1;
 
 -- name: CreateCandidateActor :one
 INSERT INTO

--- a/web/admin/components/user-queue-actions.vue
+++ b/web/admin/components/user-queue-actions.vue
@@ -35,7 +35,7 @@ async function process(did: string, action: ApprovalQueueAction) {
     >
     <span class="md:ml-auto max-md:w-full flex items-baseline">
       <span v-if="pending" class="text-xs text-gray-700 mx-1">
-        ({{ pending }} more...)
+        ({{ pending > 100 ? "100+" : pending }} more...)
       </span>
       <button
         class="py-0.5 px-2 max-md:ml-auto mr-1 text-white bg-blue-500 dark:bg-blue-600 rounded-lg hover:bg-blue-600 dark:hover:bg-blue-700 disabled:bg-blue-300 disabled:dark:bg-blue-500 disabled:cursor-not-allowed"

--- a/web/admin/pages/index.vue
+++ b/web/admin/pages/index.vue
@@ -6,7 +6,11 @@ const pending = ref(0);
 const actor = ref<Actor>();
 
 const nextActor = async () => {
-  const queue = await api.listActors({ filterStatus: ActorStatus.PENDING });
+  const queue = await api.listActors({
+    filterStatus: ActorStatus.PENDING,
+    limit: 102,
+  });
+
   pending.value = queue.actors.length - 1;
   actor.value = queue.actors[0];
 };


### PR DESCRIPTION
This limits the number of actor profiles loaded in the approval queue on initial load and any subsequent refresh to 102.

While this change hides the true number of accounts in the queue, this prevents that in the admittedly unlikely but possible [scenario described by Toon](https://discord.com/channels/1107564504021209189/1133465803350605964/1142609332647764038) (internal), we can process the queue relatively performant.

In the long term, I want to show the total number of queued accounts and only load a single account—especially with how we might change how the queue is interacted with—, but for now this is a good patch.

## Screenshots

Because of the limit change, the pending count now summarizes the pending count as **100+** if there are more than 100 accounts in the queue.

| Before | After |
| --- | --- |
| ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/7e5de409-83fd-499e-98e7-7e65deb9f16f) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/0d532a0c-9975-4957-abb8-28e63a9663e7) |