### PR TITLE
Use avatar component in user links

### DIFF
--- a/web/admin/components/shared/avatar.vue
+++ b/web/admin/components/shared/avatar.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-defineProps<{ url?: string }>();
+defineProps<{ url?: string; size: number }>();
 </script>
 
 <template>
@@ -7,14 +7,14 @@ defineProps<{ url?: string }>();
     v-if="url"
     class="rounded-full"
     :src="url"
-    height="72"
-    width="72"
+    :height="size"
+    :width="size"
     alt=""
   />
   <svg
     v-else
-    width="72"
-    height="72"
+    :width="size"
+    :height="size"
     viewBox="0 0 24 24"
     fill="none"
     stroke="none"

--- a/web/admin/components/user-card.vue
+++ b/web/admin/components/user-card.vue
@@ -59,7 +59,7 @@ await loadProfile();
     />
 
     <div class="flex gap-3 items-center mb-5">
-      <shared-avatar :url="data.avatar" />
+      <shared-avatar :url="data.avatar" :size="72" />
       <div class="flex flex-col">
         <div class="text-lg">{{ data.displayName || data.handle }}</div>
         <div class="meta">

--- a/web/admin/components/user-link.vue
+++ b/web/admin/components/user-link.vue
@@ -11,13 +11,7 @@ const { data } = await getProfile(props.did);
     class="flex items-center underline hover:no-underline"
     :href="`/users/${data.did}`"
   >
-    <img
-      class="rounded-full mr-1"
-      :src="data.avatar"
-      height="20"
-      width="20"
-      alt=""
-    />
+    <shared-avatar class="mr-1" :url="data.avatar" :size="20" />
     {{ data.handle }}
   </nuxt-link>
 </template>


### PR DESCRIPTION
This fixes that there is no fallback avatar in user links by using the existing avatar component in a smaller size.

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/9440c8ed-358d-4bbd-9eea-a7b3a64f279b) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/82d4171b-5020-4d8e-b682-6786e3aa3e52) |