### PR TITLE
feat: error handling on admin page

### DIFF
--- a/web/admin/app.vue
+++ b/web/admin/app.vue
@@ -29,10 +29,11 @@ async function login() {
     .login(identifier.value, password.value)
     .catch((error) => ({ error }));
 
-  if (isSignedIn.error)
+  if (isSignedIn.error) {
     error.value = {
-      message: isSignedIn.error
+      message: isSignedIn.error,
     };
+  }
 }
 </script>
 
@@ -43,20 +44,28 @@ async function login() {
   </div>
   <div v-else class="flex items-center justify-center fixed w-full h-full">
     <div
-      class="mx-auto bg-gray-50 border border-gray-400 dark:border-gray-700 dark:bg-gray-800 py-4 px-5 rounded-lg w-[400px] max-w-[80vw]">
+      class="mx-auto bg-gray-50 border border-gray-400 dark:border-gray-700 dark:bg-gray-800 py-4 px-5 rounded-lg w-[400px] max-w-[80vw]"
+    >
       <h1 class="text-3xl font-bold mb-4">Login</h1>
 
       <div class="flex flex-col mb-4">
         <label class="font-bold mb-1" for="name">Handle</label>
-        <input id="name" v-model="identifier"
-          class="bg-white dark:bg-gray-900 rounded border border-gray-400 dark:border-gray-700 px-2 py-1" type="text" />
+        <input
+          id="name"
+          v-model="identifier"
+          class="bg-white dark:bg-gray-900 rounded border border-gray-400 dark:border-gray-700 px-2 py-1"
+          type="text"
+        />
       </div>
 
       <div class="flex flex-col mb-4">
         <label class="font-bold mb-1" for="password">App password</label>
-        <input id="password" v-model="password"
+        <input
+          id="password"
+          v-model="password"
           class="bg-white dark:bg-gray-900 rounded border border-gray-400 dark:border-gray-700 px-2 py-1"
-          type="password" />
+          type="password"
+        />
       </div>
 
       <div class="flex">

--- a/web/admin/app.vue
+++ b/web/admin/app.vue
@@ -24,11 +24,15 @@ const user = await useUser();
 
 async function login() {
   error.value = null;
+
   const isSignedIn = await auth
     .login(identifier.value, password.value)
     .catch((error) => ({ error }));
 
-  error.value = !isSignedIn;
+  if (isSignedIn.error)
+    error.value = {
+      message: isSignedIn.error
+    };
 }
 </script>
 
@@ -39,31 +43,26 @@ async function login() {
   </div>
   <div v-else class="flex items-center justify-center fixed w-full h-full">
     <div
-      class="mx-auto bg-gray-50 border border-gray-400 dark:border-gray-700 dark:bg-gray-800 py-4 px-5 rounded-lg w-[400px] max-w-[80vw]"
-    >
+      class="mx-auto bg-gray-50 border border-gray-400 dark:border-gray-700 dark:bg-gray-800 py-4 px-5 rounded-lg w-[400px] max-w-[80vw]">
       <h1 class="text-3xl font-bold mb-4">Login</h1>
 
       <div class="flex flex-col mb-4">
         <label class="font-bold mb-1" for="name">Handle</label>
-        <input
-          id="name"
-          v-model="identifier"
-          class="bg-white dark:bg-gray-900 rounded border border-gray-400 dark:border-gray-700 px-2 py-1"
-          type="text"
-        />
+        <input id="name" v-model="identifier"
+          class="bg-white dark:bg-gray-900 rounded border border-gray-400 dark:border-gray-700 px-2 py-1" type="text" />
       </div>
 
       <div class="flex flex-col mb-4">
         <label class="font-bold mb-1" for="password">App password</label>
-        <input
-          id="password"
-          v-model="password"
+        <input id="password" v-model="password"
           class="bg-white dark:bg-gray-900 rounded border border-gray-400 dark:border-gray-700 px-2 py-1"
-          type="password"
-        />
+          type="password" />
       </div>
 
       <div class="flex">
+        <label v-if="error" class="mr-auto px-1 py-2 text-red-600">
+          {{ error.message }}
+        </label>
         <button class="ml-auto px-3 py-2 rounded-lg bg-blue-600" @click="login">
           Login
         </button>

--- a/web/admin/pages/audit-log.vue
+++ b/web/admin/pages/audit-log.vue
@@ -5,18 +5,13 @@ const error = ref<{
   rawMessage: string;
 }>(null);
 
-const { auditEvents } = await api.listAuditEvents({})
-  .then((res) => {
-    error.value = null;
-    return res;
-  })
-  .catch((err) => {
-    error.value = { rawMessage: err.rawMessage };
+const { auditEvents } = await api.listAuditEvents({}).catch((err) => {
+  error.value = { rawMessage: err.rawMessage };
 
-    return {
-      auditEvents: [],
-    }
-  });
+  return {
+    auditEvents: [],
+  }
+});
 </script>
 
 <template>

--- a/web/admin/pages/audit-log.vue
+++ b/web/admin/pages/audit-log.vue
@@ -1,28 +1,31 @@
 <script setup lang="ts">
 const api = await useAPI();
 
-const error = ref<{
-  rawMessage: string;
-}>(null);
+const error = ref<string>(null);
 
 const { auditEvents } = await api.listAuditEvents({}).catch((err) => {
-  error.value = { rawMessage: err.rawMessage };
+  error.value = err.rawMessage;
 
   return {
     auditEvents: [],
-  }
+  };
 });
 </script>
 
 <template>
   <div>
-    <shared-card v-if="error">{{ error.rawMessage }}</shared-card>
+    <shared-card v-if="error">{{ error }}</shared-card>
     <div v-else>
       <h1 class="text-xl font-bold">Audit log</h1>
       <p class="text-gray-600 dark:text-gray-400">
         Showing the last 100 audit events.
       </p>
-      <action v-for="event in auditEvents" :key="event.id" :action="event" lookup-user />
+      <action
+        v-for="event in auditEvents"
+        :key="event.id"
+        :action="event"
+        lookup-user
+      />
     </div>
   </div>
 </template>

--- a/web/admin/pages/audit-log.vue
+++ b/web/admin/pages/audit-log.vue
@@ -1,20 +1,33 @@
 <script setup lang="ts">
 const api = await useAPI();
 
-const { auditEvents } = await api.listAuditEvents({});
+const error = ref<{
+  rawMessage: string;
+}>(null);
+
+const { auditEvents } = await api.listAuditEvents({})
+  .then((res) => {
+    error.value = null;
+    return res;
+  })
+  .catch((err) => {
+    error.value = { rawMessage: err.rawMessage };
+
+    return {
+      auditEvents: [],
+    }
+  });
 </script>
 
 <template>
   <div>
-    <h1 class="text-xl font-bold">Audit log</h1>
-    <p class="text-gray-600 dark:text-gray-400">
-      Showing the last 100 audit events.
-    </p>
-    <action
-      v-for="event in auditEvents"
-      :key="event.id"
-      :action="event"
-      lookup-user
-    />
+    <shared-card v-if="error">{{ error.rawMessage }}</shared-card>
+    <div v-else>
+      <h1 class="text-xl font-bold">Audit log</h1>
+      <p class="text-gray-600 dark:text-gray-400">
+        Showing the last 100 audit events.
+      </p>
+      <action v-for="event in auditEvents" :key="event.id" :action="event" lookup-user />
+    </div>
   </div>
 </template>

--- a/web/admin/pages/index.vue
+++ b/web/admin/pages/index.vue
@@ -4,9 +4,24 @@ import { Actor, ActorStatus } from "../../proto/bff/v1/moderation_service_pb";
 const api = await useAPI();
 const pending = ref(0);
 const actor = ref<Actor>();
+const error = ref<{
+  rawMessage: string;
+}>(null);
 
 const nextActor = async () => {
-  const queue = await api.listActors({ filterStatus: ActorStatus.PENDING });
+  const queue = await api.listActors({ filterStatus: ActorStatus.PENDING })
+    .then((res) => {
+      error.value = null;
+      return res;
+    })
+    .catch((err) => {
+      error.value = { rawMessage: err.rawMessage }
+
+      return {
+        actors: [],
+      }
+    });
+
   pending.value = queue.actors.length - 1;
   actor.value = queue.actors[0];
 };
@@ -15,12 +30,7 @@ await nextActor();
 </script>
 
 <template>
-  <user-card
-    v-if="actor"
-    :did="actor.did"
-    :pending="pending"
-    variant="queue"
-    @next="nextActor"
-  />
+  <shared-card v-if="error">{{ error.rawMessage }}</shared-card>
+  <user-card v-else-if="actor" :did="actor.did" :pending="pending" variant="queue" @next="nextActor" />
   <shared-card v-else> No user is in the queue. </shared-card>
 </template>

--- a/web/admin/pages/index.vue
+++ b/web/admin/pages/index.vue
@@ -4,20 +4,20 @@ import { Actor, ActorStatus } from "../../proto/bff/v1/moderation_service_pb";
 const api = await useAPI();
 const pending = ref(0);
 const actor = ref<Actor>();
-const error = ref<{
-  rawMessage: string;
-}>(null);
+const error = ref<string>(null);
 
 const nextActor = async () => {
   error.value = null;
 
-  const queue = await api.listActors({ filterStatus: ActorStatus.PENDING }).catch((err) => {
-    error.value = { rawMessage: err.rawMessage }
+  const queue = await api
+    .listActors({ filterStatus: ActorStatus.PENDING })
+    .catch((err) => {
+      error.value = err.rawMessage;
 
-    return {
-      actors: [],
-    }
-  });
+      return {
+        actors: [],
+      };
+    });
 
   pending.value = queue.actors.length - 1;
   actor.value = queue.actors[0];
@@ -27,7 +27,13 @@ await nextActor();
 </script>
 
 <template>
-  <shared-card v-if="error">{{ error.rawMessage }}</shared-card>
-  <user-card v-else-if="actor" :did="actor.did" :pending="pending" variant="queue" @next="nextActor" />
+  <shared-card v-if="error">{{ error }}</shared-card>
+  <user-card
+    v-else-if="actor"
+    :did="actor.did"
+    :pending="pending"
+    variant="queue"
+    @next="nextActor"
+  />
   <shared-card v-else> No user is in the queue. </shared-card>
 </template>

--- a/web/admin/pages/index.vue
+++ b/web/admin/pages/index.vue
@@ -9,18 +9,15 @@ const error = ref<{
 }>(null);
 
 const nextActor = async () => {
-  const queue = await api.listActors({ filterStatus: ActorStatus.PENDING })
-    .then((res) => {
-      error.value = null;
-      return res;
-    })
-    .catch((err) => {
-      error.value = { rawMessage: err.rawMessage }
+  error.value = null;
 
-      return {
-        actors: [],
-      }
-    });
+  const queue = await api.listActors({ filterStatus: ActorStatus.PENDING }).catch((err) => {
+    error.value = { rawMessage: err.rawMessage }
+
+    return {
+      actors: [],
+    }
+  });
 
   pending.value = queue.actors.length - 1;
   actor.value = queue.actors[0];

--- a/web/admin/pages/users/[did].vue
+++ b/web/admin/pages/users/[did].vue
@@ -21,34 +21,31 @@ async function loadProfile() {
 const auditEvents: Ref<AuditEvent[]> = ref([]);
 
 async function loadEvents() {
+  error.value = null;
+
   const response = await api.listAuditEvents({
     filterSubjectDid: subject.value.did,
-  })
-    .then((res) => {
-      error.value = null;
-      return res;
-    })
-    .catch((err) => {
-      error.value = { rawMessage: err.rawMessage };
-      return {
-        auditEvents: [],
-      };
-    });
+  }).catch((err) => {
+    error.value = { rawMessage: err.rawMessage };
+    return {
+      auditEvents: [],
+    };
+  });
   auditEvents.value = response.auditEvents;
 }
 
 async function comment(comment: string) {
+  error.value = null;
+
   await api.createCommentAuditEvent({
     subjectDid: subject.value.did,
     comment,
-  })
-    .then(() => {
-      error.value = null;
-    })
-    .catch((err) => {
-      error.value = { rawMessage: err.rawMessage };
-    });
-  await loadEvents();
+  }).catch((err) => {
+    error.value = { rawMessage: err.rawMessage };
+  });
+
+  if (!error.value)
+    await loadEvents();
 }
 
 async function refresh() {


### PR DESCRIPTION
This adds visible error messages to the queue, audit log, and profile pages if an error occurs, instead of erroring silently.

## Screenshots

| Page | Screenshot |
| --- | --- |
| Queue | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/20ab8519-11d0-47ca-89de-5807ba36439e) |
| Audit log | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/4a62596d-218e-453d-8839-8812b79a4dcf) |
| Profile | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/0be4bd60-45ed-4ee9-82bd-4f6b113c436d) |