### PR TITLE
Show reason for force-approvals

### DIFF
--- a/web/admin/components/action.vue
+++ b/web/admin/components/action.vue
@@ -87,7 +87,8 @@ const comment = computed(() => {
   } else if (
     data instanceof UnapproveActorAuditPayload ||
     data instanceof BanActorAuditPayload ||
-    data instanceof CreateActorAuditPayload
+    data instanceof CreateActorAuditPayload ||
+    data instanceof ForceApproveActorAuditPayload
   ) {
     return data.reason;
   }


### PR DESCRIPTION
This fixes a bug where the reason of force-approvals would never show up.

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/37e0b24f-3041-4ff6-99ed-ba8c5a433a13) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/7efab984-5ebf-4dd1-a473-e9f35a29767a) |