### PR TITLE
add furry-hot-nsfw feed

### DIFF
--- a/feed/feed.go
+++ b/feed/feed.go
@@ -221,6 +221,17 @@ func ServiceWithDefaultFeeds(pgxStore *store.PGXStore) *Service {
 	}, preScoredGenerator(preScoredGeneratorOpts{
 		Alg: "classic",
 	}))
+	r.Register(Meta{
+		ID:          "furry-hot-nsfw",
+		DisplayName: "🐾 Hot 🌙",
+		Description: "Hottest NSFW posts by furries across Bluesky. Contains only NSFW content.\n\nJoin the furry feeds by following @furryli.st",
+		Priority:    100,
+	}, preScoredGenerator(preScoredGeneratorOpts{
+		Alg: "classic",
+		generatorOpts: generatorOpts{
+			IsNSFW: tristate.True,
+		},
+	}))
 
 	// Reverse chronological based feeds
 	r.Register(Meta{

--- a/scoring/materializer.go
+++ b/scoring/materializer.go
@@ -32,21 +32,22 @@ func NewMaterializer(
 }
 
 func (m *Materializer) materialize(ctx context.Context) error {
-	start := time.Now()
-	seq, err := m.store.MaterializeClassicPostScores(ctx, m.opts.LookbackPeriod)
+	now := time.Now()
+	seq, err := m.store.MaterializeClassicPostScores(ctx, now.Add(-m.opts.LookbackPeriod))
 	if err != nil {
 		return err
 	}
 	m.log.Info(
 		"materialized generation",
 		zap.Int64("seq", seq),
-		zap.Duration("duration", time.Since(start)),
+		zap.Duration("duration", time.Since(now)),
 	)
 	return nil
 }
 
 func (m *Materializer) cleanup(ctx context.Context) error {
-	n, err := m.store.DeleteOldPostScores(ctx, m.opts.RetentionPeriod)
+	now := time.Now()
+	n, err := m.store.DeleteOldPostScores(ctx, now.Add(-m.opts.RetentionPeriod))
 	if err != nil {
 		return err
 	}

--- a/store/postgres.go
+++ b/store/postgres.go
@@ -800,10 +800,10 @@ func (s *PGXStore) GetActorProfileHistory(ctx context.Context, did string) (out 
 	return out, convertPGXError(err)
 }
 
-func (s *PGXStore) MaterializeClassicPostScores(ctx context.Context, lookbackPeriod time.Duration) (int64, error) {
-	return s.queries.MaterializePostScores(ctx, pgtype.Interval{Valid: true, Microseconds: lookbackPeriod.Microseconds()})
+func (s *PGXStore) MaterializeClassicPostScores(ctx context.Context, after time.Time) (int64, error) {
+	return s.queries.MaterializePostScores(ctx, pgtype.Timestamptz{Time: after, Valid: true})
 }
 
-func (s *PGXStore) DeleteOldPostScores(ctx context.Context, retentionPeriod time.Duration) (int64, error) {
-	return s.queries.DeleteOldPostScores(ctx, pgtype.Interval{Valid: true, Microseconds: retentionPeriod.Microseconds()})
+func (s *PGXStore) DeleteOldPostScores(ctx context.Context, before time.Time) (int64, error) {
+	return s.queries.DeleteOldPostScores(ctx, pgtype.Timestamptz{Time: before, Valid: true})
 }

--- a/store/queries/candidate_posts.sql
+++ b/store/queries/candidate_posts.sql
@@ -1,7 +1,14 @@
 -- name: CreateCandidatePost :exec
 INSERT INTO
 candidate_posts (
-    uri, actor_did, created_at, indexed_at, hashtags, has_media, raw, self_labels
+    uri,
+    actor_did,
+    created_at,
+    indexed_at,
+    hashtags,
+    has_media,
+    raw,
+    self_labels
 )
 VALUES
 ($1, $2, $3, $4, $5, $6, $7, $8);
@@ -20,31 +27,40 @@ FROM
     candidate_posts AS cp
 INNER JOIN candidate_actors AS ca ON cp.actor_did = ca.did
 WHERE
-      -- Only include posts by approved actors
-      ca.status = 'approved'
-      -- Remove posts hidden by our moderators
-  AND cp.is_hidden = false
-      -- Remove posts deleted by the actors
-  AND cp.deleted_at IS NULL
-      -- Match at least one of the queried hashtags. If unspecified, do not filter.
-  AND (
+    -- Only include posts by approved actors
+    ca.status = 'approved'
+    -- Remove posts hidden by our moderators
+    AND cp.is_hidden = false
+    -- Remove posts deleted by the actors
+    AND cp.deleted_at IS NULL
+    AND (
     -- Standard criteria.
-    (
-        (COALESCE(@hashtags::TEXT[], '{}') = '{}' OR
-            @hashtags::TEXT[] && cp.hashtags)
+        (
+            -- Match at least one of the queried hashtags.
+            -- If unspecified, do not filter.
+            (
+                COALESCE(sqlc.narg(hashtags)::TEXT [], '{}') = '{}'
+                OR sqlc.arg(hashtags)::TEXT [] && cp.hashtags
+            )
             -- Match has_media status. If unspecified, do not filter.
-        AND (sqlc.narg(has_media)::BOOLEAN IS NULL OR
-            COALESCE(cp.has_media, false) = @has_media)
+            AND (
+                sqlc.narg(has_media)::BOOLEAN IS NULL
+                OR COALESCE(cp.has_media, false) = sqlc.narg(has_media)
+            )
             -- Filter by NSFW status. If unspecified, do not filter.
-        AND (sqlc.narg(is_nsfw)::BOOLEAN IS NULL OR
-            ((ARRAY ['nsfw', 'mursuit', 'murrsuit'] && cp.hashtags) OR
-                (ARRAY ['porn', 'nudity', 'sexual'] && cp.self_labels)) = @is_nsfw)
-    ) OR
-    -- Pinned DID criteria.
-    cp.actor_did = ANY(@pinned_dids::TEXT[])
-  )
-      -- Remove posts newer than the cursor timestamp
-  AND (cp.indexed_at < @cursor_timestamp)
+            AND (
+                sqlc.narg(is_nsfw)::BOOLEAN IS NULL
+                OR (
+                    (ARRAY['nsfw', 'mursuit', 'murrsuit'] && cp.hashtags)
+                    OR (ARRAY['porn', 'nudity', 'sexual'] && cp.self_labels)
+                ) = sqlc.narg(is_nsfw)
+            )
+        )
+        -- Pinned DID criteria.
+        OR cp.actor_did = ANY(sqlc.arg(pinned_dids)::TEXT [])
+    )
+    -- Remove posts newer than the cursor timestamp
+    AND (cp.indexed_at < sqlc.arg(cursor_timestamp))
 ORDER BY
     cp.indexed_at DESC
 LIMIT sqlc.arg(_limit);
@@ -66,28 +82,34 @@ FROM
 INNER JOIN candidate_actors AS ca ON cp.actor_did = ca.did
 INNER JOIN post_scores AS ph
     ON
-        ph.uri = cp.uri AND ph.alg = sqlc.arg(alg)
+        cp.uri = ph.uri AND ph.alg = sqlc.arg(alg)
         AND ph.generation_seq = sqlc.arg(generation_seq)
 WHERE
     cp.is_hidden = false
     AND ca.status = 'approved'
+    -- Match at least one of the queried hashtags.
+    -- If unspecified, do not filter.
     AND (
-        COALESCE(sqlc.arg(hashtags)::TEXT [], '{}') = '{}'
-        OR sqlc.arg(hashtags)::TEXT [] && cp.hashtags
+        COALESCE(sqlc.narg(hashtags)::TEXT [], '{}') = '{}'
+        OR sqlc.narg(hashtags)::TEXT [] && cp.hashtags
     )
+    -- Match has_media status. If unspecified, do not filter.
     AND (
         sqlc.narg(has_media)::BOOLEAN IS NULL
         OR COALESCE(cp.has_media, false) = sqlc.narg(has_media)
     )
+    -- Filter by NSFW status. If unspecified, do not filter.
     AND (
         sqlc.narg(is_nsfw)::BOOLEAN IS NULL
-        OR (ARRAY['nsfw', 'mursuit', 'murrsuit'] && cp.hashtags)
-        = sqlc.narg(is_nsfw)
+        OR (
+            (ARRAY['nsfw', 'mursuit', 'murrsuit'] && cp.hashtags)
+            OR (ARRAY['porn', 'nudity', 'sexual'] && cp.self_labels)
+        ) = sqlc.narg(is_nsfw)
     )
     AND cp.deleted_at IS NULL
     AND (
-        (ph.score, ph.uri)
-        < (sqlc.arg(after_score)::REAL, sqlc.arg(after_uri)::TEXT)
+        ROW(ph.score, ph.uri)
+        < ROW((sqlc.arg(after_score))::REAL, (sqlc.arg(after_uri))::TEXT)
     )
 ORDER BY
     ph.score DESC, ph.uri DESC

--- a/store/queries/post_scoring.sql
+++ b/store/queries/post_scoring.sql
@@ -1,6 +1,6 @@
 -- name: DeleteOldPostScores :execrows
 DELETE FROM post_scores
-WHERE generated_at < NOW() - sqlc.arg(retention_period)::INTERVAL;
+WHERE generated_at < sqlc.arg(before)::TIMESTAMPTZ;
 
 -- name: MaterializePostScores :one
 WITH seq AS (SELECT NEXTVAL('post_scores_generation_seq') AS seq)
@@ -20,7 +20,7 @@ SELECT
 FROM candidate_posts AS cp
 WHERE
     cp.deleted_at IS NULL
-    AND cp.created_at >= NOW() - sqlc.arg(lookback_period)::INTERVAL
+    AND cp.created_at >= sqlc.arg(after)::TIMESTAMPTZ
 RETURNING (SELECT seq FROM seq);
 
 -- name: GetLatestScoreGeneration :one


### PR DESCRIPTION
this also:
- reformats all the queries
- changes materializer queries to take a timestamptz rather than an interval. this allows us to run the materializer independently of the system clock

the prescored test cases are just copied over from the chronological test cases, for now.