### PR TITLE
Make queue action buttons larger on mobile

### DIFF
--- a/web/admin/components/user-card.vue
+++ b/web/admin/components/user-card.vue
@@ -46,7 +46,7 @@ await loadProfile();
     <user-queue-actions
       v-if="status === ActorStatus.PENDING"
       :did="data.did"
-      :handle="data.handle"
+      :name="data.displayName || data.handle.replace(/.bsky.social$/, '')"
       :pending="pending"
       @next="next"
       @loading="loading = true"

--- a/web/admin/components/user-queue-actions.vue
+++ b/web/admin/components/user-queue-actions.vue
@@ -3,7 +3,7 @@ import { ApprovalQueueAction } from "../../proto/bff/v1/moderation_service_pb";
 
 const props = defineProps<{
   did: string;
-  handle: string;
+  name: string;
   pending?: number;
 }>();
 const $emit = defineEmits(["loading", "next"]);
@@ -30,15 +30,19 @@ async function process(did: string, action: ApprovalQueueAction) {
   <div
     class="mb-3 rounded-lg bg-orange-400 text-black px-3 py-1 flex items-baseline text-sm max-md:flex-col"
   >
-    <span class="max-md:order-1"
-      >{{ handle }} requested to be on the feed.</span
+    <span class="max-w-full flex max-md:mb-1"
+      ><span class="truncate">{{ name }}</span>
+      &nbsp;
+      <span class="flex-shrink-0">requested to be on the feed.</span></span
     >
-    <span class="md:ml-auto max-md:w-full flex items-baseline">
+    <span
+      class="md:ml-auto max-md:w-full flex items-baseline max-md:items-center"
+    >
       <span v-if="pending" class="text-xs text-gray-700 mx-1">
-        ({{ pending }} more...)
+        (and {{ pending }} more...)
       </span>
       <button
-        class="py-0.5 px-2 max-md:ml-auto mr-1 text-white bg-blue-500 dark:bg-blue-600 rounded-lg hover:bg-blue-600 dark:hover:bg-blue-700 disabled:bg-blue-300 disabled:dark:bg-blue-500 disabled:cursor-not-allowed"
+        class="py-0.5 max-md:py-1 max-md:px-3 px-2 max-md:ml-auto mr-1 text-white bg-blue-500 dark:bg-blue-600 rounded-lg hover:bg-blue-600 dark:hover:bg-blue-700 disabled:bg-blue-300 disabled:dark:bg-blue-500 disabled:cursor-not-allowed"
         :disabled="loading"
         @click="accept"
       >
@@ -46,7 +50,7 @@ async function process(did: string, action: ApprovalQueueAction) {
       </button>
 
       <button
-        class="py-0.5 px-2 bg-red-500 dark:bg-red-600 hover:bg-red-600 dark:hover:bg-red-700 disabled:bg-red-400 disabled:dark:bg-red-500 rounded-lg disabled:cursor-not-allowed"
+        class="py-0.5 max-md:py-1 max-md:px-3 px-2 bg-red-500 dark:bg-red-600 hover:bg-red-600 dark:hover:bg-red-700 disabled:bg-red-400 disabled:dark:bg-red-500 rounded-lg disabled:cursor-not-allowed"
         :disabled="loading"
         @click="reject"
       >


### PR DESCRIPTION
This makes the queue action buttons larger on mobile as suggested [internally](https://discord.com/channels/1107564504021209189/1126239623283212410/1152072259125653507) (internal link) and changes the layout a bit.

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/5c00de53-9065-42df-b3b8-2e052fd97e64) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/81d5b59d-8943-418f-a320-15a74749c132) |