### PR TITLE
Add option to confirm queue actions

### DIFF
--- a/web/admin/components/core/nav.vue
+++ b/web/admin/components/core/nav.vue
@@ -1,6 +1,5 @@
 <script setup>
 import { search } from "~/lib/search";
-import { logout } from "~/lib/auth";
 
 const profile = await useProfile();
 const showSearch = ref(false);
@@ -34,19 +33,15 @@ async function doSearch() {
 
     <div class="ml-auto flex items-center gap-2">
       <shared-search @toggle-search="showSearch = !showSearch" />
-      <img
-        class="rounded-full"
-        :src="profile.avatar"
-        height="32"
-        width="32"
-        alt=""
-      />
-      <button
-        class="text-white bg-gray-700 px-2 py-1 rounded-lg"
-        @click="logout"
-      >
-        Logout
-      </button>
+      <nuxt-link href="/settings">
+        <img
+          class="rounded-full"
+          :src="profile.avatar"
+          height="32"
+          width="32"
+          alt=""
+        />
+      </nuxt-link>
     </div>
   </nav>
   <div

--- a/web/admin/components/user-queue-actions.vue
+++ b/web/admin/components/user-queue-actions.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { showQueueActionConfirmation } from "~/lib/settings";
 import { ApprovalQueueAction } from "../../proto/bff/v1/moderation_service_pb";
 
 const props = defineProps<{
@@ -15,6 +16,13 @@ const reject = () => process(props.did, ApprovalQueueAction.REJECT);
 
 const api = await useAPI();
 async function process(did: string, action: ApprovalQueueAction) {
+  if (showQueueActionConfirmation.value) {
+    const verb = action === ApprovalQueueAction.APPROVE ? "approve" : "reject";
+
+    if (!confirm(`Do you want to ${verb} ${props.handle}?`)) {
+      return;
+    }
+  }
   loading.value = true;
   $emit("loading");
   await api.processApprovalQueue({

--- a/web/admin/lib/settings.ts
+++ b/web/admin/lib/settings.ts
@@ -1,0 +1,13 @@
+const SHOW_QUEUE_ACTION_CONFIRMATION = "bff-show-queue-action-confirmation";
+
+export const showQueueActionConfirmation = ref(
+  localStorage.getItem(SHOW_QUEUE_ACTION_CONFIRMATION) === "true"
+);
+
+watch(showQueueActionConfirmation, (show) => {
+  if (show) {
+    localStorage.setItem(SHOW_QUEUE_ACTION_CONFIRMATION, "true");
+  } else {
+    localStorage.removeItem(SHOW_QUEUE_ACTION_CONFIRMATION);
+  }
+});

--- a/web/admin/pages/settings.vue
+++ b/web/admin/pages/settings.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { showQueueActionConfirmation } from "~/lib/settings";
+import { logout } from "~/lib/auth";
+</script>
+
+<template>
+  <div>
+    <h1 class="text-xl font-bold">My settings</h1>
+    <p class="text-gray-600 dark:text-gray-400 mb-4">
+      Settings aren’t synced across your devices.
+    </p>
+
+    <div class="flex gap-2 mb-4">
+      <input
+        id="show-queue-action-confirmation"
+        v-model="showQueueActionConfirmation"
+        type="checkbox"
+      />
+      <label for="show-queue-action-confirmation"
+        >Show confirmation popup when approving and rejecting in the
+        queue.</label
+      >
+    </div>
+
+    <button class="text-white bg-gray-700 px-2 py-1 rounded-lg" @click="logout">
+      Logout
+    </button>
+  </div>
+</template>


### PR DESCRIPTION
This moves the **Login** button out of the navbar into a separate settings page (accessed by clicking the avatar in the navbar) and adds a setting to confirm queue actions to reduce the chance of accidentally approving or rejecting a queued user if desired by the moderator.

## Screenshots

![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/a1018222-6680-452f-b558-ed924226c18a)
