### PR TITLE
Fix error icon is shrinking

### DIFF
--- a/web/admin/components/shared/card.vue
+++ b/web/admin/components/shared/card.vue
@@ -11,7 +11,7 @@ defineProps<{ noPadding?: boolean; variant?: "error" }>();
       'flex gap-2 items-center': variant,
     }"
   >
-    <icon-cross-octagon v-if="variant === 'error'" />
+    <icon-cross-octagon v-if="variant === 'error'" class="flex-shrink-0" />
     <slot />
   </div>
 </template>


### PR DESCRIPTION
This fixes a small UI bug where if the database can’t be reached the error icon would shrink, which we don’t want, so the error message looks consistent.

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/e6c6ecb9-7ef9-4ffa-8937-d2a12fa0168f) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/24c8a905-d7a4-4f26-9f64-32def7a964dd) |