### PR TITLE
Add sqlfluff CI job

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -39,3 +39,14 @@ jobs:
       - run: sqlc generate
       - name: Check that sqlc queries are up-to-date
         run: git diff --exit-code
+  lint-sql:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "actions/checkout@v2"
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.8"
+      - name: Install sqlfluff
+        run: "pip install sqlfluff==2.3.2"
+      - name: Lint sql files
+        run: "sqlfluff lint"

--- a/store/gen/candidate_posts.sql.go
+++ b/store/gen/candidate_posts.sql.go
@@ -62,7 +62,7 @@ WHERE
     -- Only include posts by approved actors
     ca.status = 'approved'
     -- Remove posts hidden by our moderators
-    AND cp.is_hidden = false
+    AND cp.is_hidden = FALSE
     -- Remove posts deleted by the actors
     AND cp.deleted_at IS NULL
     AND (
@@ -77,7 +77,7 @@ WHERE
             -- Match has_media status. If unspecified, do not filter.
             AND (
                 $2::BOOLEAN IS NULL
-                OR COALESCE(cp.has_media, false) = $2
+                OR COALESCE(cp.has_media, FALSE) = $2
             )
             -- Filter by NSFW status. If unspecified, do not filter.
             AND (
@@ -184,7 +184,7 @@ INNER JOIN post_scores AS ph
         cp.uri = ph.uri AND ph.alg = $1
         AND ph.generation_seq = $2
 WHERE
-    cp.is_hidden = false
+    cp.is_hidden = FALSE
     AND ca.status = 'approved'
     -- Match at least one of the queried hashtags.
     -- If unspecified, do not filter.
@@ -195,7 +195,7 @@ WHERE
     -- Match has_media status. If unspecified, do not filter.
     AND (
         $4::BOOLEAN IS NULL
-        OR COALESCE(cp.has_media, false) = $4
+        OR COALESCE(cp.has_media, FALSE) = $4
     )
     -- Filter by NSFW status. If unspecified, do not filter.
     AND (

--- a/store/queries/candidate_posts.sql
+++ b/store/queries/candidate_posts.sql
@@ -30,7 +30,7 @@ WHERE
     -- Only include posts by approved actors
     ca.status = 'approved'
     -- Remove posts hidden by our moderators
-    AND cp.is_hidden = false
+    AND cp.is_hidden = FALSE
     -- Remove posts deleted by the actors
     AND cp.deleted_at IS NULL
     AND (
@@ -45,7 +45,7 @@ WHERE
             -- Match has_media status. If unspecified, do not filter.
             AND (
                 sqlc.narg(has_media)::BOOLEAN IS NULL
-                OR COALESCE(cp.has_media, false) = sqlc.narg(has_media)
+                OR COALESCE(cp.has_media, FALSE) = sqlc.narg(has_media)
             )
             -- Filter by NSFW status. If unspecified, do not filter.
             AND (
@@ -85,7 +85,7 @@ INNER JOIN post_scores AS ph
         cp.uri = ph.uri AND ph.alg = sqlc.arg(alg)
         AND ph.generation_seq = sqlc.arg(generation_seq)
 WHERE
-    cp.is_hidden = false
+    cp.is_hidden = FALSE
     AND ca.status = 'approved'
     -- Match at least one of the queried hashtags.
     -- If unspecified, do not filter.
@@ -96,7 +96,7 @@ WHERE
     -- Match has_media status. If unspecified, do not filter.
     AND (
         sqlc.narg(has_media)::BOOLEAN IS NULL
-        OR COALESCE(cp.has_media, false) = sqlc.narg(has_media)
+        OR COALESCE(cp.has_media, FALSE) = sqlc.narg(has_media)
     )
     -- Filter by NSFW status. If unspecified, do not filter.
     AND (


### PR DESCRIPTION
This adds the [sqlfluff](https://github.com/sqlfluff/sqlfluff) linter for SQL files as CI job.

Closes #162 