### PR TITLE
Batch profile requests to speed up fetching

### DIFF
--- a/web/admin/components/user-card.vue
+++ b/web/admin/components/user-card.vue
@@ -16,10 +16,9 @@ const loading = ref(false);
 const status = ref<ActorStatus>();
 const data = ref<ProfileViewDetailed>();
 const loadProfile = async () => {
-  const result = await getProfile(props.did);
-  data.value = result.data;
+  data.value = await getProfile(props.did);
   const { actor } = await api
-    .getActor({ did: result.data.did })
+    .getActor({ did: data.value.did })
     .catch(() => ({ actor: undefined }));
   isArtist.value = Boolean(actor?.isArtist);
   status.value = actor?.status;

--- a/web/admin/components/user-link.vue
+++ b/web/admin/components/user-link.vue
@@ -3,15 +3,15 @@ import { getProfile } from "~/lib/cached-bsky";
 
 const props = defineProps<{ did: string }>();
 
-const { data } = await getProfile(props.did);
+const profile = await getProfile(props.did);
 </script>
 
 <template>
   <nuxt-link
     class="flex items-center underline hover:no-underline"
-    :href="`/users/${data.did}`"
+    :href="`/users/${profile.did}`"
   >
-    <shared-avatar class="mr-1" :url="data.avatar" :size="20" />
-    {{ data.handle }}
+    <shared-avatar class="mr-1" :url="profile.avatar" :size="20" />
+    {{ profile.handle }}
   </nuxt-link>
 </template>

--- a/web/admin/lib/cached-bsky.ts
+++ b/web/admin/lib/cached-bsky.ts
@@ -1,17 +1,55 @@
-import { AppBskyActorGetProfile } from "@atproto/api";
 import { newAgent } from "./auth";
+import { ProfileViewDetailed } from "@atproto/api/dist/client/types/app/bsky/actor/defs";
 
-const cache: Map<string, Promise<AppBskyActorGetProfile.Response>> = new Map();
+class BatchDidQueue<K, T extends { did: string }> {
+  private items: { key: K; resolve: (value: T | PromiseLike<T>) => void }[] =
+    [];
+  private timer: any = null;
+  private readonly maxItems = 25;
 
-export async function getProfile(
-  did: string
-): Promise<AppBskyActorGetProfile.Response> {
+  constructor(private readonly exec: (k: K[]) => Promise<T[]>) {}
+
+  async add(key: K): Promise<T> {
+    return new Promise((resolve) => {
+      this.items.push({ key, resolve });
+
+      if (this.items.length >= this.maxItems) {
+        this.dispatch();
+      } else if (!this.timer) {
+        this.timer = setTimeout(() => this.dispatch(), 50);
+      }
+    });
+  }
+
+  private async dispatch() {
+    if (this.items.length === 0) return;
+    const keys = this.items.slice(0, this.maxItems);
+    this.items = this.items.slice(this.maxItems);
+    this.timer = null;
+
+    const results = await this.exec(keys.map((k) => k.key));
+
+    for (const { key, resolve } of keys) {
+      const result = results.find((result) => result.did === key);
+      resolve(result as T);
+    }
+  }
+}
+
+const cache: Map<string, Promise<ProfileViewDetailed>> = new Map();
+const queue = new BatchDidQueue((dids: string[]) =>
+  newAgent()
+    .getProfiles({ actors: dids })
+    .then((r) => r.data.profiles)
+);
+
+export async function getProfile(did: string): Promise<ProfileViewDetailed> {
   let profile = cache.get(did);
   if (profile) {
     return profile;
   }
 
-  profile = newAgent().getProfile({ actor: did });
+  profile = queue.add(did);
 
   cache.set(did, profile);
 


### PR DESCRIPTION
This speeds up loading the profile requests by batching the requests together and using `getProfiles` instead of `getProfile`.

## Comparison

On the audit log:

| Metric | Before | After |
| --- | --- | --- |
| Nuxt tools: Page load time | 12.5s | 1.7s |
| Chrome finish time | 14.8s | 5s |

## In summary

![](https://media.tenor.com/yRrrJYgNXfUAAAAd/the-dog.gif)