### PR TITLE
Update navbar Discord link

### DIFF
--- a/web/info/src/lib/constants.ts
+++ b/web/info/src/lib/constants.ts
@@ -26,7 +26,7 @@ export const NAV_OPTIONS = [
     text: 'Community Guidelines'
   },
   {
-    href: 'https://discord.gg/7X467r4UXF',
+    href: 'https://discord.gg/C59qZTuzU5',
     target: '_blank',
     text: 'Discord'
   }


### PR DESCRIPTION
Related to [this message](https://discord.com/channels/1107564504021209189/1133465803350605964/1161053791525801984) (internal), this fixes the Discord link in the navbar of [the info page](https://furryli.st).