### PR TITLE
Enable queue 'Hold back' button

### DIFF
--- a/web/admin/components/user-queue-actions.vue
+++ b/web/admin/components/user-queue-actions.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { showQueueActionConfirmation } from "~/lib/settings";
 import { ApprovalQueueAction } from "../../proto/bff/v1/moderation_service_pb";
-import { Duration } from "@bufbuild/protobuf";
 
 const props = defineProps<{
   did: string;
@@ -89,7 +88,6 @@ async function holdBack() {
       </button>
 
       <button
-        v-if="false /* waiting for backend deployment! */"
         class="py-0.5 max-md:py-1 whitespace-nowrap max-md:px-3 px-2 text-white bg-gray-500 dark:bg-gray-600 hover:bg-gray-600 dark:hover:bg-gray-700 disabled:bg-gray-400 disabled:dark:bg-gray-500 rounded-lg disabled:cursor-not-allowed"
         :disabled="loading"
         @click="holdBack"


### PR DESCRIPTION
Following #172 and the latest backend deployment, this enables the **Hold back** button in the queue.