### PR TITLE
Fix deleted users in queue cant be rejected

### DIFF
--- a/web/admin/components/user-card.vue
+++ b/web/admin/components/user-card.vue
@@ -18,7 +18,7 @@ const data = ref<ProfileViewDetailed>();
 const loadProfile = async () => {
   data.value = await getProfile(props.did);
   const { actor } = await api
-    .getActor({ did: data.value.did })
+    .getActor({ did: data.value?.did || props.did })
     .catch(() => ({ actor: undefined }));
   isArtist.value = Boolean(actor?.isArtist);
   status.value = actor?.status;
@@ -100,9 +100,20 @@ await loadProfile();
       />
     </div>
   </shared-card>
-  <shared-card v-else class="bg-red-200 dark:bg-red-700">
-    Profile with did {{ did }} was not found.
-  </shared-card>
+  <template v-else>
+    <user-queue-actions
+      v-if="status === ActorStatus.PENDING"
+      :did="props.did"
+      :name="props.did"
+      :pending="pending"
+      reject-only
+      @next="next"
+      @loading="loading = true"
+    />
+    <shared-card class="bg-red-200 dark:bg-red-700">
+      Profile with did {{ did }} was not found.
+    </shared-card>
+  </template>
 </template>
 
 <style scoped>

--- a/web/admin/components/user-queue-actions.vue
+++ b/web/admin/components/user-queue-actions.vue
@@ -6,6 +6,7 @@ const props = defineProps<{
   did: string;
   name: string;
   pending?: number;
+  rejectOnly?: boolean;
 }>();
 const $emit = defineEmits(["loading", "next"]);
 
@@ -72,6 +73,7 @@ async function holdBack() {
         ({{ pending }} more...)
       </span>
       <button
+        v-if="!rejectOnly"
         class="py-0.5 max-md:py-1 max-md:px-3 px-2 max-md:ml-auto mr-1 text-white bg-blue-500 dark:bg-blue-600 rounded-lg hover:bg-blue-600 dark:hover:bg-blue-700 disabled:bg-blue-300 disabled:dark:bg-blue-500 disabled:cursor-not-allowed"
         :disabled="loading"
         @click="accept"
@@ -88,6 +90,7 @@ async function holdBack() {
       </button>
 
       <button
+        v-if="!rejectOnly"
         class="py-0.5 max-md:py-1 whitespace-nowrap max-md:px-3 px-2 text-white bg-gray-500 dark:bg-gray-600 hover:bg-gray-600 dark:hover:bg-gray-700 disabled:bg-gray-400 disabled:dark:bg-gray-500 rounded-lg disabled:cursor-not-allowed"
         :disabled="loading"
         @click="holdBack"


### PR DESCRIPTION
This fixes a bug where a deleted user in the queue results in a fatal error showing just a blank screen.

## Screenshots
| Before | After |
| --- | --- |
| ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/2ee81efc-35cd-413a-8cbd-6e657f55e6f7) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/adb866e0-c598-4c57-b628-54a0ddad50b2) |