### PR TITLE
Fix deleted user on audit log page and profile

### DIFF
--- a/web/admin/components/user-card.vue
+++ b/web/admin/components/user-card.vue
@@ -100,7 +100,7 @@ await loadProfile();
       />
     </div>
   </shared-card>
-  <template v-else>
+  <div v-else>
     <user-queue-actions
       v-if="status === ActorStatus.PENDING"
       :did="props.did"
@@ -113,7 +113,7 @@ await loadProfile();
     <shared-card class="bg-red-200 dark:bg-red-700">
       Profile with did {{ did }} was not found.
     </shared-card>
-  </template>
+  </div>
 </template>
 
 <style scoped>

--- a/web/admin/components/user-link.vue
+++ b/web/admin/components/user-link.vue
@@ -9,9 +9,9 @@ const profile = await getProfile(props.did);
 <template>
   <nuxt-link
     class="flex items-center underline hover:no-underline"
-    :href="`/users/${profile.did}`"
+    :href="`/users/${profile?.did || did}`"
   >
-    <shared-avatar class="mr-1" :url="profile.avatar" :size="20" />
-    {{ profile.handle }}
+    <shared-avatar class="mr-1" :url="profile?.avatar" :size="20" />
+    {{ profile?.handle || did }}
   </nuxt-link>
 </template>


### PR DESCRIPTION
Following #185, this fixes that deleted user links are not shown on the audit log page and that the profile page doesn’t load.

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/8658ca39-9f94-4e3c-811e-359d072902f5) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/edd4c931-465c-4c07-b103-fa694fc74dad) |
| ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/a7568c21-c82e-48bd-b7b3-ec17b6279525) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/1d5586c1-3af5-4bff-8b58-a5204356076f) |