### PR TITLE
Remove artist checkmark from user profiles

### DIFF
--- a/web/admin/components/user-card.vue
+++ b/web/admin/components/user-card.vue
@@ -11,7 +11,6 @@ const props = defineProps<{
 const $emit = defineEmits(["next"]);
 
 const api = await useAPI();
-const isArtist = ref(false);
 const loading = ref(false);
 const status = ref<ActorStatus>();
 const data = ref<ProfileViewDetailed>();
@@ -20,7 +19,6 @@ const loadProfile = async () => {
   const { actor } = await api
     .getActor({ did: data.value?.did || props.did })
     .catch(() => ({ actor: undefined }));
-  isArtist.value = Boolean(actor?.isArtist);
   status.value = actor?.status;
 };
 
@@ -81,13 +79,6 @@ await loadProfile();
           <span class="meta-item">
             {{ data.postsCount }}
             <span class="text-muted">posts</span>
-          </span>
-        </div>
-        <div v-if="variant === 'profile'" class="meta">
-          <span class="meta-item inline-flex items-center">
-            <icon-check v-if="isArtist" class="text-green-500" />
-            <icon-cross v-else class="text-red-500" />
-            <span class="text-muted">Artist</span>
           </span>
         </div>
       </div>


### PR DESCRIPTION
This removes the **Artist** checkmark from user profiles as it’s currently unused because of the art feeds.

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/31674085-3cb2-4f88-8077-ce5d38e5d733) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/5c52a5a4-bc12-4bf5-96db-4859a4680de8) |