### PR TITLE
Handle queue action errors with alert

### DIFF
--- a/web/admin/components/user-queue-actions.vue
+++ b/web/admin/components/user-queue-actions.vue
@@ -32,11 +32,18 @@ async function process(
   }
   loading.value = true;
   $emit("loading");
-  await api.processApprovalQueue({
-    did,
-    action,
-    reason,
-  });
+  try {
+    await api.processApprovalQueue({
+      did,
+      action,
+      reason,
+    });
+  } catch (err) {
+    const message = String(err);
+    if (!message.includes("candidate actor status was")) {
+      alert("An error occurred while processing the queue: " + message);
+    }
+  }
   $emit("next");
   loading.value = false;
 }
@@ -53,12 +60,19 @@ async function holdBack() {
 
   loading.value = true;
   $emit("loading");
-  await api.holdBackPendingActor({
-    did: props.did,
-    duration: {
-      seconds: BigInt(60 * 60 * 24 * 2),
-    },
-  });
+  try {
+    await api.holdBackPendingActor({
+      did: props.did,
+      duration: {
+        seconds: BigInt(60 * 60 * 24 * 2),
+      },
+    });
+  } catch (err) {
+    const message = String(err);
+    if (!message.includes("candidate actor status was")) {
+      alert("An error occurred while holding back the user: " + message);
+    }
+  }
   $emit("next");
   loading.value = false;
 }


### PR DESCRIPTION
This adds calls to `alert()` when one of the queue actions fails. The only exception is if the user is not pending, so we gracefully fail over to the next actor in the queue.

## Screenshots

![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/603f92f4-2aae-4eb8-b4f0-98c7bd1236b9)
