### PR TITLE
Fix reject options are white in light mode

### DIFF
--- a/web/admin/components/reject-reason-modal.vue
+++ b/web/admin/components/reject-reason-modal.vue
@@ -38,7 +38,7 @@ function handleCheck(reason: string, value: boolean) {
   <div
     class="fixed flex top-0 left-0 right-0 bottom-0 z-10 justify-center items-center"
   >
-    <shared-card class="text-white z-10 bg-white dark:bg-gray-900">
+    <shared-card class="dark:text-white z-10 bg-white dark:bg-gray-900">
       <h2 class="text-lg font-bold">Reject {{ name }}</h2>
       <p class="text-muted mb-3">
         Please select all applicable reasons for the rejection.


### PR DESCRIPTION
This fixes that the options in the reject modal are white (i.e. unreadable) in light mode.

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/ae23f94f-be7b-4019-8975-c6b446146472) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/6adbb568-2ffb-4cb2-93eb-9e1001b11a4d) |