### PR TITLE
Show audit log in queue

### DIFF
--- a/web/admin/components/user/audit-log.vue
+++ b/web/admin/components/user/audit-log.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { ProfileViewDetailed } from "@atproto/api/dist/client/types/app/bsky/actor/defs";
+import { AuditEvent } from "../../../proto/bff/v1/moderation_service_pb";
+
+const $emit = defineEmits<{
+  (event: "error", message: string): void;
+}>();
+const props = defineProps<{
+  did: string;
+  subject?: ProfileViewDetailed;
+  hideCommentBox?: boolean;
+}>();
+
+const auditEvents: Ref<AuditEvent[]> = ref([]);
+
+async function loadEvents() {
+  $emit("error", "");
+
+  const response = await api
+    .listAuditEvents({
+      filterSubjectDid: props.did,
+    })
+    .catch((err) => {
+      $emit("error", err.rawMessage);
+      return {
+        auditEvents: [],
+      };
+    });
+  auditEvents.value = response.auditEvents;
+}
+
+defineExpose({
+  refresh() {
+    loadEvents();
+  },
+});
+
+async function comment(comment: string) {
+  $emit("error", "");
+
+  let ok = true;
+
+  await api
+    .createCommentAuditEvent({
+      subjectDid: props.did,
+      comment,
+    })
+    .catch((err) => {
+      ok = false;
+      $emit("error", err.rawMessage);
+    });
+
+  if (ok) await loadEvents();
+}
+const api = await useAPI();
+await loadEvents();
+</script>
+
+<template>
+  <h2 class="font-bold mb-3">Comments</h2>
+  <action
+    v-for="action in auditEvents.sort(
+      (a, b) =>
+        (a.createdAt?.toDate().getTime() || 0) -
+        (b.createdAt?.toDate().getTime() || 0)
+    )"
+    :key="action.id"
+    :action="action"
+  />
+  <p v-if="auditEvents.length === 0 && hideCommentBox" class="text-muted">
+    No comments or audit events.
+  </p>
+  <shared-comment-box v-if="subject && !hideCommentBox" @comment="comment" />
+</template>

--- a/web/admin/components/user/profile.vue
+++ b/web/admin/components/user/profile.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { newAgent } from "~/lib/auth";
+import { ProfileViewDetailed } from "@atproto/api/dist/client/types/app/bsky/actor/defs";
+
+const props = defineProps<{
+  did: string;
+  pending?: number;
+  variant: "profile" | "queue";
+}>();
+defineEmits<{
+  (event: "next"): void;
+}>();
+
+const error = ref<string>();
+const auditLog = ref() as Ref<{ refresh(): Promise<void> }>;
+
+const subject = ref<ProfileViewDetailed>();
+const agent = newAgent();
+async function loadProfile() {
+  const { data } = await agent
+    .getProfile({
+      actor: props.did,
+    })
+    .catch(() => {
+      return { data: undefined };
+    });
+  subject.value = data;
+}
+
+async function refresh() {
+  await loadProfile();
+  await auditLog.value?.refresh();
+}
+
+watch(
+  () => props.did,
+  () => refresh()
+);
+
+await refresh();
+</script>
+
+<template>
+  <div>
+    <shared-card v-if="error" variant="error">{{ error }}</shared-card>
+    <div v-else>
+      <user-card
+        class="mb-5"
+        :did="subject?.did || String($route.params.did)"
+        :pending="pending"
+        :variant="variant"
+        @next="$emit('next')"
+      />
+      <user-audit-log
+        ref="auditLog"
+        :subject="subject"
+        :hide-comment-box="variant === 'queue'"
+        :did="subject?.did || String($route.params.did)"
+      />
+    </div>
+  </div>
+</template>

--- a/web/admin/pages/index.vue
+++ b/web/admin/pages/index.vue
@@ -33,7 +33,7 @@ await nextActor();
 
 <template>
   <shared-card v-if="error" variant="error">{{ error }}</shared-card>
-  <user-card
+  <user-profile
     v-else-if="actor"
     :did="actor.did"
     :pending="pending"

--- a/web/admin/pages/users/[did].vue
+++ b/web/admin/pages/users/[did].vue
@@ -1,90 +1,15 @@
 <script setup lang="ts">
-import { newAgent } from "~/lib/auth";
-import { AuditEvent } from "../../../proto/bff/v1/moderation_service_pb";
-import { ProfileViewDetailed } from "@atproto/api/dist/client/types/app/bsky/actor/defs";
-
-const api = await useAPI();
-
-const error = ref<string>();
-
-const subject = ref<ProfileViewDetailed>();
-const agent = newAgent();
-async function loadProfile(did: string) {
-  const { data } = await agent
-    .getProfile({
-      actor: did,
-    })
-    .catch(() => {
-      return { data: undefined };
-    });
-  subject.value = data;
-}
-
-const auditEvents: Ref<AuditEvent[]> = ref([]);
-
-async function loadEvents(fallbackDid: string) {
-  error.value = "";
-
-  const response = await api
-    .listAuditEvents({
-      filterSubjectDid: subject.value?.did || fallbackDid,
-    })
-    .catch((err) => {
-      error.value = err.rawMessage;
-      return {
-        auditEvents: [],
-      };
-    });
-  auditEvents.value = response.auditEvents;
-}
-
-async function comment(comment: string) {
-  error.value = "";
-
-  const did = subject.value?.did || String(useRoute().params.did);
-
-  await api
-    .createCommentAuditEvent({
-      subjectDid: did,
-      comment,
-    })
-    .catch((err) => {
-      error.value = err.rawMessage;
-    });
-
-  if (!error.value) await loadEvents(did);
-}
-
-async function refresh() {
-  const did = String(useRoute().params.did);
-  await loadProfile(did);
-  await loadEvents(did);
-}
-
-await refresh();
+const did = ref(String(useRoute().params.did));
+watch(
+  () => String(useRoute().params.did),
+  (newDid) => {
+    if (newDid) {
+      did.value = newDid;
+    }
+  }
+);
 </script>
 
 <template>
-  <div>
-    <shared-card v-if="error" variant="error">{{ error }}</shared-card>
-    <div v-else>
-      <user-card
-        class="mb-5"
-        :did="subject?.did || String($route.params.did)"
-        variant="profile"
-        @next="refresh"
-      />
-      <h2 class="font-bold mb-3">Comments</h2>
-      <action
-        v-for="action in auditEvents.sort(
-          (a, b) =>
-            (a.createdAt?.toDate().getTime() || 0) -
-            (b.createdAt?.toDate().getTime() || 0)
-        )"
-        :key="action.id"
-        :action="action"
-      />
-      <shared-comment-box v-if="subject" @comment="comment" />
-    </div>
-  </div>
+  <user-profile :did="did" variant="profile" />
 </template>


### PR DESCRIPTION
This adds the audit log to the queue, excluding the comment box, so the only actions are the queue actions.

This makes it obvious when an account has been held back before.

## Screenshots

![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/9af0678b-faee-4f5e-b79c-760cdb871335)