### PR TITLE
Resize avatars depending on display size

### DIFF
--- a/web/admin/components/core/nav.vue
+++ b/web/admin/components/core/nav.vue
@@ -34,12 +34,11 @@ async function doSearch() {
     <div class="ml-auto flex items-center gap-2">
       <shared-search @toggle-search="showSearch = !showSearch" />
       <nuxt-link href="/settings">
-        <img
-          class="rounded-full"
-          :src="profile.avatar"
-          height="32"
-          width="32"
-          alt=""
+        <shared-avatar
+          :did="profile.did"
+          :has-avatar="profile.avatar"
+          resize="72x72"
+          :size="32"
         />
       </nuxt-link>
     </div>

--- a/web/admin/components/shared/avatar.vue
+++ b/web/admin/components/shared/avatar.vue
@@ -1,10 +1,25 @@
 <script lang="ts" setup>
-defineProps<{ url?: string; size: number }>();
+const props = defineProps<{
+  did?: string;
+  hasAvatar: boolean;
+  resize?: "72x72" | "20x20";
+  size: number;
+}>();
+
+const url = computed(() => {
+  let base = `https://bsky-cdn.codingpa.ws/avatar/${props.did}`;
+
+  if (props.resize) {
+    base += `/${props.resize}`;
+  }
+
+  return base;
+});
 </script>
 
 <template>
   <img
-    v-if="url"
+    v-if="did && hasAvatar"
     class="rounded-full"
     :src="url"
     :height="size"

--- a/web/admin/components/user-card.vue
+++ b/web/admin/components/user-card.vue
@@ -56,7 +56,12 @@ await loadProfile();
     />
 
     <div class="flex gap-3 items-center mb-5">
-      <shared-avatar :url="data.avatar" :size="72" />
+      <shared-avatar
+        :did="data.did"
+        :has-avatar="Boolean(data.avatar)"
+        resize="72x72"
+        :size="72"
+      />
       <div class="flex flex-col">
         <div class="text-lg">{{ data.displayName || data.handle }}</div>
         <div class="meta">

--- a/web/admin/components/user-link.vue
+++ b/web/admin/components/user-link.vue
@@ -11,7 +11,13 @@ const profile = await getProfile(props.did);
     class="flex items-center underline hover:no-underline"
     :href="`/users/${profile?.did || did}`"
   >
-    <shared-avatar class="mr-1" :url="profile?.avatar" :size="20" />
+    <shared-avatar
+      class="mr-1"
+      :did="profile?.did"
+      resize="20x20"
+      :has-avatar="Boolean(profile?.avatar)"
+      :size="20"
+    />
     {{ profile?.handle || did }}
   </nuxt-link>
 </template>


### PR DESCRIPTION
This changes the avatars to be resized depending on the size they’re displayed at because the size of the avatar provided by Bluesky is a humongous 1000x1000, whereas we currently only need 72x72 and 20x20.

The resize service is loosely based on [relaea](https://gitlab.com/codingpaws/relaea) but also fetches the avatar url from Bluesky, such as [`https://bsky-cdn.codingpa.ws/avatar/ottr.sh/72x72`](https://bsky-cdn.codingpa.ws/avatar/ottr.sh/72x72), so it’s easier to use.

## Stats

On the audit log page (because it has the most images):

| Metric | Before | After | Change |
| --- | --- | --- | --- |
| Bytes transferred (images only) | 8.8 MB | 72.7 KB | -99.17 % |
| Finish | 4.82 s | 4.19 s | -13.07 % |