### PR TITLE
Prevent race conditions when loading description

### DIFF
--- a/web/admin/components/shared/bsky/description.vue
+++ b/web/admin/components/shared/bsky/description.vue
@@ -7,12 +7,17 @@ const props = defineProps<{ description: string }>();
 const segments = ref();
 
 const updateDescription = async () => {
+  const description = props.description;
   const descriptionRichText = new atproto.RichText(
-    { text: props.description },
+    { text: description },
     { cleanNewlines: true }
   );
   await descriptionRichText.detectFacets(newAgent());
-  segments.value = [...descriptionRichText.segments()];
+
+  // prevent race conditions
+  if (description === props.description) {
+    segments.value = [...descriptionRichText.segments()];
+  }
 };
 
 onMounted(updateDescription);


### PR DESCRIPTION
This fixes a race condition that can happen when someone approves a user fast enough and the rich description of the now approved user finishes after the next user’s description is loaded.

Right now, this is unlikely to happen but with the planned pre-categorization, it becomes more likely.