### PR TITLE
Fix duplicate session requests

### DIFF
--- a/web/admin/composables/useUser.ts
+++ b/web/admin/composables/useUser.ts
@@ -5,9 +5,17 @@ export default async function (): Promise<Ref<AtpSessionData>> {
   const user = useState("user");
   const session = useCookie(COOKIE_NAME).value;
 
-  if (session) {
+  if (session && !user.value) {
     user.value = await fetchUser();
   }
 
   return user as Ref<AtpSessionData>;
 }
+
+/**
+ * 6.23
+12 XHR requests
+
+3.76
+7 XHR requests
+ */

--- a/web/admin/composables/useUser.ts
+++ b/web/admin/composables/useUser.ts
@@ -11,11 +11,3 @@ export default async function (): Promise<Ref<AtpSessionData>> {
 
   return user as Ref<AtpSessionData>;
 }
-
-/**
- * 6.23
-12 XHR requests
-
-3.76
-7 XHR requests
- */


### PR DESCRIPTION
This fixes that the user store is ignored and the site always requests the user session when we only need it once on page load.

## Metrics

On the index page with a single user in the queue:

| Metric | Before | After |
| --- | --- | --- |
| Load finish | 6.23s | 3.76s |
| Request count | 12 | 7 |