### PR TITLE
Add large avatar preview

### DIFF
--- a/web/admin/components/core/modal.vue
+++ b/web/admin/components/core/modal.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+defineEmits<{
+  (event: "close"): void;
+}>();
+</script>
+
+<template>
+  <div
+    class="fixed flex top-0 left-0 right-0 bottom-0 z-10 justify-center items-center"
+  >
+    <slot />
+    <div
+      class="bg-black bg-opacity-50 absolute top-0 left-0 right-0 bottom-0"
+      @click="$emit('close')"
+    />
+  </div>
+</template>

--- a/web/admin/components/reject-reason-modal.vue
+++ b/web/admin/components/reject-reason-modal.vue
@@ -36,9 +36,7 @@ function handleCheck(reason: string, value: boolean) {
 </script>
 
 <template>
-  <div
-    class="fixed flex top-0 left-0 right-0 bottom-0 z-10 justify-center items-center"
-  >
+  <core-modal @close="$emit('cancel')">
     <shared-card class="dark:text-white z-10 bg-white dark:bg-gray-900">
       <h2 class="text-lg font-bold">Reject {{ name }}</h2>
       <p class="text-muted mb-3">
@@ -105,9 +103,5 @@ function handleCheck(reason: string, value: boolean) {
         </button>
       </div>
     </shared-card>
-    <div
-      class="bg-black bg-opacity-50 absolute top-0 left-0 right-0 bottom-0"
-      @click="$emit('cancel')"
-    />
-  </div>
+  </core-modal>
 </template>

--- a/web/admin/components/shared/avatar.vue
+++ b/web/admin/components/shared/avatar.vue
@@ -2,7 +2,7 @@
 const props = defineProps<{
   did?: string;
   hasAvatar: boolean;
-  resize?: "72x72" | "20x20";
+  resize?: "72x72" | "20x20" | "webp";
   size: number;
 }>();
 

--- a/web/admin/components/user-card.vue
+++ b/web/admin/components/user-card.vue
@@ -11,6 +11,7 @@ const props = defineProps<{
 const $emit = defineEmits(["next"]);
 
 const api = await useAPI();
+const showAvatarModal = ref(false);
 const loading = ref(false);
 const status = ref<ActorStatus>();
 const data = ref<ProfileViewDetailed>();
@@ -56,12 +57,33 @@ await loadProfile();
     />
 
     <div class="flex gap-3 items-center mb-5">
-      <shared-avatar
-        :did="data.did"
-        :has-avatar="Boolean(data.avatar)"
-        resize="72x72"
-        :size="72"
-      />
+      <button
+        class="relative flex overflow-hidden rounded-full"
+        @click="showAvatarModal = true"
+      >
+        <shared-avatar
+          :did="data.did"
+          :has-avatar="Boolean(data.avatar)"
+          resize="72x72"
+          :size="72"
+        />
+        <span
+          class="opacity-0 hover:opacity-100 transition duration-300 w-full h-full absolute flex items-center bg-black bg-opacity-50 text-xs uppercase tracking-tight"
+        >
+          Click to zoom
+        </span>
+      </button>
+      <core-modal v-if="showAvatarModal" @close="showAvatarModal = false">
+        <div class="z-10">
+          <shared-avatar
+            class="w-auto h-auto max-h-[80vh] max-w-[80vw]"
+            :did="data.did"
+            :has-avatar="Boolean(data.avatar)"
+            resize="webp"
+            :size="512"
+          />
+        </div>
+      </core-modal>
       <div class="flex flex-col">
         <div class="text-lg">{{ data.displayName || data.handle }}</div>
         <div class="meta">


### PR DESCRIPTION
This adds a “Click to zoom” avatar preview like on Bluesky because sometimes the avatar is the decisive factor that someone is a furry.

## Screenshots

![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/8f3f693f-0097-490a-b6c0-28ef2e000991)

