### PR TITLE
Add BLFC 2023 feed

### DIFF
--- a/feed/feed.go
+++ b/feed/feed.go
@@ -369,6 +369,18 @@ func ServiceWithDefaultFeeds(pgxStore *store.PGXStore) *Service {
 		},
 	}))
 	r.Register(Meta{
+		ID:          "con-blfc",
+		DisplayName: "🐾 BLFC 2023",
+		Description: "A feed for all things BLFC! Use #blfc, #blfc23, or #blfc2023 to include a post in the feed.\n\nJoin the furry feeds by following @furryli.st",
+	}, chronologicalGenerator(chronologicalGeneratorOpts{
+		generatorOpts: generatorOpts{
+			Hashtags: []string{
+				"blfc", "blfc23", "blfc2023",
+			},
+			DisallowedHashtags: defaultDisallowedHashtags,
+		},
+	}))
+	r.Register(Meta{
 		ID:          "merch",
 		DisplayName: "🐾 #FurSale",
 		Description: "Buy and sell furry merch on the FurSale feed. Use #fursale or #merch to include a post in the feed.\n\nJoin the furry feeds by following @furryli.st",


### PR DESCRIPTION
This adds the BLFC feed (`con-blfc`) for next week’s BLFC 2023.

The feed hashtags are: `#blfc`, `#blfc23`, and `#blfc2023`