### PR TITLE
Rename "No avatar or bio" to "Empty profiles"

### DIFF
--- a/web/admin/pages/index.vue
+++ b/web/admin/pages/index.vue
@@ -58,11 +58,11 @@ const queues = computed(() => ({
 
     return false;
   }),
-  "No avatar or bio": actors.value.filter((actor) => {
+  "Empty profiles": actors.value.filter((actor) => {
     const profile = didToProfile(actor.did);
     if (!profile) return false;
 
-    return !profile.avatar || !profile.description;
+    return !profile.avatar && !profile.description;
   }),
   "Held back": heldBack.value,
 }));


### PR DESCRIPTION
This fixes the **No avatar or bio** category by only showing profiles that are empty, so have neither an avatar nor a bio, as originally intended but falsely fixed in 23221d7.

This also renames the category to **Empty profiles**, so it’s less ambiguous what the category means.

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/0afcb801-3d77-42d9-98f5-0a94288ead35) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/4bdbae1e-8023-4e86-9294-e3fff00a3675)