### PR TITLE
Add Discord shortlink

### DIFF
--- a/web/info/src/lib/constants.ts
+++ b/web/info/src/lib/constants.ts
@@ -26,7 +26,7 @@ export const NAV_OPTIONS = [
     text: 'Community Guidelines'
   },
   {
-    href: 'https://discord.gg/C59qZTuzU5',
+    href: '/discord',
     target: '_blank',
     text: 'Discord'
   }

--- a/web/info/src/routes/discord/+page.server.ts
+++ b/web/info/src/routes/discord/+page.server.ts
@@ -1,0 +1,5 @@
+import { redirect } from '@sveltejs/kit';
+
+export function load() {
+  throw redirect(302, 'https://discord.com/invite/9aMHDCYnT6');
+}


### PR DESCRIPTION
This adds a Discord shortlink at `https://furryli.st/discord` that redirects with a 302 Found to the current Discord invite.