### PR TITLE
Fix `overflow-x` bug on chrome

### DIFF
--- a/web/info/src/styles/app.scss
+++ b/web/info/src/styles/app.scss
@@ -6,6 +6,8 @@ body {
   background-color: #f5f5f4;
   width: 100vw;
   height: 100vh;
+  overflow: hidden;
+  overflow-x: clip;
   overflow-y: scroll;
 }
 


### PR DESCRIPTION
Set `overflow-x` to `clip` on body to prevent odd overflow.