### PR TITLE
Fix crash when actor profile doesn’t exist

### DIFF
--- a/web/admin/pages/index.vue
+++ b/web/admin/pages/index.vue
@@ -88,7 +88,7 @@ const nextActor = async () => {
   heldBack.value = queue.actors.filter(isHeldBack);
   actorProfiles.value = await Promise.all(
     actors.value.map((a) => a.did).map(getProfile)
-  );
+  ).then((p) => p.filter(Boolean));
   selectRandomActor();
 };
 


### PR DESCRIPTION
This fixes a crash when there is an actor in the queue, whose profile doesn’t exist, e.g. by deletion or a takedown. We now filter out actors without profiles, though we should auto-reject them.

We used to handle the error following #185 but after adding batch profile loading in #180, we’re no longer getting an error to handle.