### PR TITLE
Improve therian matcher

### DIFF
--- a/web/admin/pages/index.vue
+++ b/web/admin/pages/index.vue
@@ -20,14 +20,18 @@ const queues = computed(() => ({
     const profile = didToProfile(actor.did);
     if (!profile?.description) return false;
 
-    if (profile.displayName?.includes("Θ∆")) {
+    // ∆ (increment operator) and Δ (delta)
+    // Θ (uppercase theta) and θ (lowercase theta)
+    const therian = /(Θ|θ)(∆|Δ)/;
+
+    if (profile.displayName?.match(therian)) {
       return true;
     }
 
     const terms = [
       "furry",
       "furries",
-      "Θ∆",
+      therian,
       "therian",
       /\bpup\b/,
       /\bfur\b/,
@@ -42,6 +46,7 @@ const queues = computed(() => ({
       /(f|m)urr?suit/,
       "otherkin",
       "protogen",
+      "fluffy",
     ];
 
     const description = profile.description.toLowerCase();


### PR DESCRIPTION
This improves the therian matcher and adds `fluffy` as another term for likely furries.

It turns out, therians use a both Θ (uppercase theta) and θ (lowercase theta) for the Theta-Delta symbol combination. But. Thanks to Unicode, there also are ∆ and Δ, two distinct symbols that are easily confused. The former is the increment operator codepoint while the latter is the correct uppercase delta symbol.