### PR TITLE
Fix deleted profile causes crash in queue

### DIFF
--- a/web/admin/components/user-card.vue
+++ b/web/admin/components/user-card.vue
@@ -119,7 +119,7 @@ await loadProfile();
     </div>
   </shared-card>
   <div v-else>
-    <user-queue-actions
+    <user-queue-banner
       v-if="status === ActorStatus.PENDING"
       :did="props.did"
       :name="props.did"
@@ -128,6 +128,7 @@ await loadProfile();
       @next="next"
       @loading="loading = true"
     />
+
     <shared-card class="bg-red-200 dark:bg-red-700">
       Profile with did {{ did }} was not found.
     </shared-card>

--- a/web/admin/components/user/profile.vue
+++ b/web/admin/components/user/profile.vue
@@ -46,7 +46,7 @@ await refresh();
     <div v-else>
       <user-card
         class="mb-5"
-        :did="subject?.did || String($route.params.did)"
+        :did="subject?.did || props.did"
         :pending="pending"
         :variant="variant"
         @next="$emit('next')"
@@ -55,7 +55,7 @@ await refresh();
         ref="auditLog"
         :subject="subject"
         :hide-comment-box="variant === 'queue'"
-        :did="subject?.did || String($route.params.did)"
+        :did="subject?.did || props.did"
       />
     </div>
   </div>


### PR DESCRIPTION
This fixes a regression previously fixed in #185, which was reintroduced in #215 because we renamed `user-queue-banner` to `user-queue-actions` and moved `web/admin/components/user/profile.vue` without using the correct did when the bsky profile doesn’t exist.