### PR TITLE
Move furry detection to separate file

### DIFF
--- a/web/admin/lib/furry-detector.ts
+++ b/web/admin/lib/furry-detector.ts
@@ -1,0 +1,57 @@
+import { ProfileViewDetailed } from "@atproto/api/dist/client/types/app/bsky/actor/defs";
+
+type ProfileViewMinimal = Pick<ProfileViewDetailed, "displayName"> &
+  Pick<ProfileViewDetailed, "description">;
+
+export function isProbablyFurry(profile?: ProfileViewMinimal): boolean {
+  if (!profile) {
+    return false;
+  }
+
+  // ∆ (increment operator) and Δ (delta)
+  // Θ (uppercase theta) and θ (lowercase theta)
+  const therian = /(Θ|θ)(∆|Δ)/;
+
+  if (profile?.displayName?.match(therian)) {
+    return true;
+  }
+
+  if (!profile.description) {
+    return false;
+  }
+
+  const terms = [
+    "furry",
+    "furries",
+    therian,
+    "therian",
+    /\bpup\b/,
+    /\bfur\b/,
+    "anthro",
+    "canine",
+    /bu?n+u*y/, // too good to not use
+    "kemono",
+    "furaffinity",
+    "derg",
+    /scal(y|ie)/,
+    /gay (fur|dog|cat|wolf)/,
+    /(f|m)urr?suit/,
+    "otherkin",
+    "protogen",
+    "fluffy",
+  ];
+
+  const description = profile.description.toLowerCase();
+
+  for (const term of terms) {
+    if (
+      typeof term === "object"
+        ? description.match(term)
+        : description.includes(term)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/web/admin/pages/index.vue
+++ b/web/admin/pages/index.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import { getProfile } from "~/lib/cached-bsky";
+import { isProbablyFurry } from "~/lib/furry-detector";
 import { Actor, ActorStatus } from "../../proto/bff/v1/types_pb";
 import { ProfileViewDetailed } from "@atproto/api/dist/client/types/app/bsky/actor/defs";
 
@@ -18,50 +19,8 @@ const queues = computed(() => ({
   All: actors.value,
   "Probably furry": actors.value.filter((actor) => {
     const profile = didToProfile(actor.did);
-    if (!profile?.description) return false;
 
-    // ∆ (increment operator) and Δ (delta)
-    // Θ (uppercase theta) and θ (lowercase theta)
-    const therian = /(Θ|θ)(∆|Δ)/;
-
-    if (profile.displayName?.match(therian)) {
-      return true;
-    }
-
-    const terms = [
-      "furry",
-      "furries",
-      therian,
-      "therian",
-      /\bpup\b/,
-      /\bfur\b/,
-      "anthro",
-      "canine",
-      /bu?n+u*y/, // too good to not use
-      "kemono",
-      "furaffinity",
-      "derg",
-      /scal(y|ie)/,
-      /gay (fur|dog|cat|wolf)/,
-      /(f|m)urr?suit/,
-      "otherkin",
-      "protogen",
-      "fluffy",
-    ];
-
-    const description = profile.description.toLowerCase();
-
-    for (const term of terms) {
-      if (
-        typeof term === "object"
-          ? description.match(term)
-          : description.includes(term)
-      ) {
-        return true;
-      }
-    }
-
-    return false;
+    return isProbablyFurry(profile);
   }),
   "Empty profiles": actors.value.filter((actor) => {
     const profile = didToProfile(actor.did);


### PR DESCRIPTION
This moves the detection logic for the **Probably furry** queue category to a separate file, so we can use it on profiles after #222 is merged.