### PR TITLE
Add MFF 2023 feed

### DIFF
--- a/feed/feed.go
+++ b/feed/feed.go
@@ -381,6 +381,18 @@ func ServiceWithDefaultFeeds(pgxStore *store.PGXStore) *Service {
 		},
 	}))
 	r.Register(Meta{
+		ID:          "con-mff",
+		DisplayName: "🐾 MFF 2023",
+		Description: "A feed for all things MFF! Use #mff, #mff23, or #mff2023 to include a post in the feed.\n\nJoin the furry feeds by following @furryli.st",
+	}, chronologicalGenerator(chronologicalGeneratorOpts{
+		generatorOpts: generatorOpts{
+			Hashtags: []string{
+				"mff", "mff23", "mff2023",
+			},
+			DisallowedHashtags: defaultDisallowedHashtags,
+		},
+	}))
+	r.Register(Meta{
 		ID:          "merch",
 		DisplayName: "🐾 #FurSale",
 		Description: "Buy and sell furry merch on the FurSale feed. Use #fursale or #merch to include a post in the feed.\n\nJoin the furry feeds by following @furryli.st",


### PR DESCRIPTION
This adds the MFF feed (`con-mff`) for next week’s MFF 2023 (Nov 3th – Dec 3rd).

The feed hashtags are: `#mff`, `#mff23`, and `#mff2023`.
