### PR TITLE
Hide user banner if not present

### DIFF
--- a/web/admin/components/user-card.vue
+++ b/web/admin/components/user-card.vue
@@ -75,9 +75,8 @@ await loadProfile();
     <div class="flex max-md:flex-col gap-3" :class="{ loading }">
       <div class="mb-3 md:w-[50%] card-list h-min flex-1">
         <user-actions :did="data.did" :status="actor?.status" @update="next" />
-        <shared-card>
+        <shared-card v-if="data.banner">
           <img
-            v-if="data.banner"
             :src="`https://bsky-cdn.codingpa.ws/banner/${did}/450x150`"
             class="w-full object-fit rounded-lg"
             height="101"


### PR DESCRIPTION
This hides the user’s banner if it’s not set.

## Screenshots

| Before | After | 
| --- | --- |
| ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/e609714e-48e3-480d-b7fd-9f387d360a57) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/9c15513c-22f4-4948-b979-4c895eb180e5) |