### PR TITLE
Add #furfest to MFF feed

### DIFF
--- a/feed/feed.go
+++ b/feed/feed.go
@@ -387,7 +387,7 @@ func ServiceWithDefaultFeeds(pgxStore *store.PGXStore) *Service {
 	}, chronologicalGenerator(chronologicalGeneratorOpts{
 		generatorOpts: generatorOpts{
 			Hashtags: []string{
-				"furfest", "mff", "mff23", "mff2023",
+				"furfest", "furfest23", "furfest2023", "mff", "mff23", "mff2023",
 			},
 			DisallowedHashtags: defaultDisallowedHashtags,
 		},

--- a/feed/feed.go
+++ b/feed/feed.go
@@ -383,11 +383,11 @@ func ServiceWithDefaultFeeds(pgxStore *store.PGXStore) *Service {
 	r.Register(Meta{
 		ID:          "con-mff",
 		DisplayName: "🐾 MFF 2023",
-		Description: "A feed for all things MFF! Use #mff, #mff23, or #mff2023 to include a post in the feed.\n\nJoin the furry feeds by following @furryli.st",
+		Description: "A feed for all things MFF! Use #furfest, #mff, #mff23, or #mff2023 to include a post in the feed.\n\nJoin the furry feeds by following @furryli.st",
 	}, chronologicalGenerator(chronologicalGeneratorOpts{
 		generatorOpts: generatorOpts{
 			Hashtags: []string{
-				"mff", "mff23", "mff2023",
+				"furfest", "mff", "mff23", "mff2023",
 			},
 			DisallowedHashtags: defaultDisallowedHashtags,
 		},


### PR DESCRIPTION
This adds the `#furfest` hashtag to the MFF feed because it’s apparently been [the official hashtag](https://bsky.app/profile/duncandahusky.wolfhusky.org/post/3kf73kmm6rh2m) for the last few years. It also adds `#furfest23` and `#furfest2023` for consistency with the mff tags.