### PR TITLE
Increase hold back period to one week

### DIFF
--- a/web/admin/components/user/queue-actions.vue
+++ b/web/admin/components/user/queue-actions.vue
@@ -62,10 +62,11 @@ async function holdBack() {
   loading.value = true;
   $emit("loading");
   try {
+    const days = 60 * 60 * 24;
     await api.holdBackPendingActor({
       did: props.did,
       duration: {
-        seconds: BigInt(60 * 60 * 24 * 2),
+        seconds: BigInt(days * 7),
       },
     });
   } catch (err) {


### PR DESCRIPTION
This increases the hold back period to one week. Because of the high number of new empty profiles, this should reduce the amount of unnecessary repeated hold backs until an account has set up their profile.