### PR TITLE
Add hyena and greymuzzle to furry detector

### DIFF
--- a/web/admin/lib/furry-detector.ts
+++ b/web/admin/lib/furry-detector.ts
@@ -36,6 +36,9 @@ export function isProbablyFurry(profile?: ProfileViewMinimal): boolean {
     /scal(y|ie)/,
     /gay (fur|dog|cat|wolf)/,
     /(f|m)urr?suit/,
+    /gr(e|a)ymuzzle/,
+    "hyena",
+    /\byeen\b/,
     "otherkin",
     "protogen",
     "fluffy",
@@ -43,7 +46,7 @@ export function isProbablyFurry(profile?: ProfileViewMinimal): boolean {
     "deer",
     "cat",
     "wolf",
-    "dragon"
+    "dragon",
   ];
 
   const description = profile.description.toLowerCase();


### PR DESCRIPTION
This adds the terms `hyena`, `yeen`, and `greymuzzle` (incl. spelling variant) to the furry detector to improve the _Probably furry_ category accuracy.