### PR TITLE
Add coyote and kitsune to furry detector

### DIFF
--- a/web/admin/lib/furry-detector.ts
+++ b/web/admin/lib/furry-detector.ts
@@ -37,6 +37,8 @@ export function isProbablyFurry(profile?: ProfileViewMinimal): boolean {
     /gay (fur|dog|cat|wolf)/,
     /(f|m)urr?suit/,
     /gr(e|a)ymuzzle/,
+    /\b(co)?yote\b/,
+    "kitsune",
     "hyena",
     /\byeen\b/,
     "otherkin",


### PR DESCRIPTION
This adds the terms (co)yote and kitsune to the furry detector.