### PR TITLE
Fix long links overflowing in bio

### DIFF
--- a/web/admin/components/shared/bsky/text.vue
+++ b/web/admin/components/shared/bsky/text.vue
@@ -7,7 +7,7 @@ defineProps<{ segment: RichTextSegment }>();
 <template>
   <nuxt-link
     v-if="segment.isLink()"
-    class="underline hover:no-underline text-blue-500"
+    class="underline hover:no-underline text-blue-500 break-all"
     :href="segment.link?.uri"
     target="_blank"
   >


### PR DESCRIPTION
This fixes that long links in user bios overflow by breaking the URL across multiple lines if it's too long.

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/f07df2ea-0ae4-453c-8d2e-f2852d12bbd7) | ![image](https://github.com/strideynet/bsky-furry-feed/assets/28510368/a6899fde-19dd-4890-93e4-8eccd39f01e2) |