### PR TITLE
Fix furry detector doesn’t match theta-delta in description

### DIFF
--- a/web/admin/lib/furry-detector.ts
+++ b/web/admin/lib/furry-detector.ts
@@ -10,7 +10,7 @@ export function isProbablyFurry(profile?: ProfileViewMinimal): boolean {
 
   // ∆ (increment operator) and Δ (delta)
   // Θ (uppercase theta) and θ (lowercase theta)
-  const therian = /(Θ|θ)(∆|Δ)/;
+  const therian = /(Θ|θ)(∆|Δ)/i;
 
   if (profile?.displayName?.match(therian)) {
     return true;


### PR DESCRIPTION
This fixes the weird behavior of the furry matcher [as described here](https://discord.com/channels/1107564504021209189/1125845147649847420/1184911245065867295) (internal). In short, in some cases (but not all!), descriptions containing the theta-delta therian symbols do not pass the furry detector, even though the regular expression allows it: `/(Θ|θ)(∆|Δ)/`.

The reason for this outlier behavior is due to lowercasing the description, which we do for simpler comparisons, as JavaScript doesn’t have a case-insentitive `strings.EqualFold` comparison. The detector passes when the profile descriptions contains an increment operator (`Δ`) but not an uppercase delta (`Δ`) as the updated description would contain a lowercase delta (`δ`) at time of regex check.

To fix this, this adds the `i` ignore-case modifier to the therian regex, allowing also `θδ` as side-effect.