### PR TITLE
Update golangci-lint-action in CI

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -35,9 +35,9 @@ jobs:
           go-version: "1.21"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.53
+          version: v1.58.2
           args: --timeout=5m
   check-sqlc:
     name: Check sqlc generation


### PR DESCRIPTION
This should hopefully fix the failing CI. It passes locally.