### PR TITLE
Add feed for Anthrocon

### DIFF
--- a/feed/feed.go
+++ b/feed/feed.go
@@ -459,6 +459,19 @@ func ServiceWithDefaultFeeds(pgxStore *store.PGXStore) *Service {
 		},
 	}))
 	r.Register(Meta{
+		ID:          "con-ac",
+		DisplayName: "🐾 Anthrocon 2024",
+		Description: "A feed for all things Anthrocon! Use #anthrocon, #anthrocon2024, or #ac to include a post in the feed.\n\nJoin the furry feeds by following @furryli.st",
+	}, chronologicalGenerator(chronologicalGeneratorOpts{
+		generatorOpts: generatorOpts{
+			Hashtags: []string{
+				"anthrocon", "anthrocon2024", "anthrocon24",
+				"ac", "ac2024", "ac24",
+			},
+			DisallowedHashtags: defaultDisallowedHashtags,
+		},
+	}))
+	r.Register(Meta{
 		ID:          "merch",
 		DisplayName: "🐾 #FurSale",
 		Description: "Buy and sell furry merch on the FurSale feed. Use #fursale or #merch to include a post in the feed.\n\nJoin the furry feeds by following @furryli.st",


### PR DESCRIPTION
This adds a feed for Anthrocon 2024, which will take place July 4-7.

The official hashtag is `#anthrocon2024` as used by [`@Anthrocon`](https://twitter.com/Anthrocon) on Twitter. This also adds other frequently used tags: `#anthrocon`, `#anthrocon24`, `#ac`, `#ac24`, and `#ac2024`.