### PR TITLE
Make search more robust

### DIFF
--- a/web/admin/lib/search.ts
+++ b/web/admin/lib/search.ts
@@ -1,9 +1,12 @@
 import { newAgent } from "./auth";
 
 export async function search(term: string) {
+  if (!term.includes(".")) {
+    term = `${term}.bsky.social`;
+  }
   const agent = newAgent();
   const { data, success } = await agent
-    .getProfile({ actor: term })
+    .getProfile({ actor: term.toLowerCase() })
     .catch(() => ({ success: false, data: undefined }));
 
   if (!success) {


### PR DESCRIPTION
This makes search more robust by:

1. inferring the `.bsky.social` suffix if it’s not present and
2. lowercasing the search term because Bluesky handles are always lowercase.