### PR TITLE
Fix tooltip always shows

### DIFF
--- a/web/admin/components/shared/bsky/text.vue
+++ b/web/admin/components/shared/bsky/text.vue
@@ -3,7 +3,7 @@ import { RichTextSegment } from "@atproto/api";
 
 defineProps<{ segment: RichTextSegment }>();
 
-const hovering = ref(true);
+const hovering = ref(false);
 
 function enter() {
   hovering.value = true;


### PR DESCRIPTION
This fixes a bug left over from testing where the tooltip would always show and only go away once you first over over a link. :facepalm: 