### PR TITLE
Always show comment box

### DIFF
--- a/web/admin/components/shared/comment-box.vue
+++ b/web/admin/components/shared/comment-box.vue
@@ -13,7 +13,7 @@ function comment() {
   <div class="flex gap-3 mt-5 mb-24 text-sm flex-col">
     <textarea
       v-model="text"
-      class="flex-1 py-2 px-2 rounded-lg border border-gray-300 text-black"
+      class="flex-1 py-2 px-2 rounded-lg border border-gray-300 bg-transparent"
       rows="4"
       placeholder="Type your comment..."
       type="text"

--- a/web/admin/components/user/audit-log.vue
+++ b/web/admin/components/user/audit-log.vue
@@ -8,7 +8,6 @@ const $emit = defineEmits<{
 const props = defineProps<{
   did: string;
   subject?: ProfileViewDetailed;
-  hideCommentBox?: boolean;
 }>();
 
 const auditEvents: Ref<AuditEvent[]> = ref([]);
@@ -67,8 +66,8 @@ await loadEvents();
     :key="action.id"
     :action="action"
   />
-  <p v-if="auditEvents.length === 0 && hideCommentBox" class="text-muted">
+  <p v-if="auditEvents.length === 0" class="text-muted">
     No comments or audit events.
   </p>
-  <shared-comment-box v-if="subject && !hideCommentBox" @comment="comment" />
+  <shared-comment-box v-if="subject" @comment="comment" />
 </template>

--- a/web/admin/components/user/profile.vue
+++ b/web/admin/components/user/profile.vue
@@ -54,7 +54,6 @@ await refresh();
       <user-audit-log
         ref="auditLog"
         :subject="subject"
-        :hide-comment-box="variant === 'queue'"
         :did="subject?.did || props.did"
       />
     </div>


### PR DESCRIPTION
This makes the comment box always show up, so we don’t have to awkwardly navigate to the user’s profile to write a comment.

This also makes the comment box background dark in dark mode, so it doesn’t flashbang you.

## Screenshots

| Page | Before | After |
| ---- | ------ | ----- |
| Queue | ![image](https://github.com/user-attachments/assets/3c2dad24-6408-43ca-8e96-70a2d6375448) | ![image](https://github.com/user-attachments/assets/e2232b2e-d82e-4647-bc6b-f5d8c6900325) |
| User | ![image](https://github.com/user-attachments/assets/1a9adf39-3b44-44df-9e81-77f81b025772) | ![image](https://github.com/user-attachments/assets/774d0480-c7a2-46a0-9dcb-52cff9c35f43) |