### PR TITLE
Fix testenv relay setup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/strideynet/bsky-furry-feed
 
-go 1.23
+go 1.23.0
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.5.2


### PR DESCRIPTION
This fixes a test regression caused by the recent upgrade in https://github.com/strideynet/bsky-furry-feed/pull/246. BGS was renamed to Relay in Indigo, so we also had to update it.