### PR TITLE
Fix comment box border in dark mode

### DIFF
--- a/web/admin/components/shared/comment-box.vue
+++ b/web/admin/components/shared/comment-box.vue
@@ -13,7 +13,7 @@ function comment() {
   <div class="flex gap-3 mt-5 mb-24 text-sm flex-col">
     <textarea
       v-model="text"
-      class="flex-1 py-2 px-2 rounded-lg border border-gray-300 bg-transparent"
+      class="flex-1 py-2 px-2 rounded-lg border border-gray-300 dark:border-gray-700 bg-transparent"
       rows="4"
       placeholder="Type your comment..."
       type="text"


### PR DESCRIPTION
This fixes the comment box border in dark mode. It was only the light mode border, which is inconsistent with the rest of the UI.

## Screenshots

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/a7d67980-2e6f-43a7-88d5-6ff2de62166f) | ![image](https://github.com/user-attachments/assets/fe9a2eed-d2c4-4c88-9bd5-5ddfaa12683f) |