### PR TITLE
Limit posts in feeds to last 7 days

### DIFF
--- a/feed/feed_test.go
+++ b/feed/feed_test.go
@@ -45,12 +45,21 @@ func TestGenerator(t *testing.T) {
 	nsfwVideoPost := indigoTest.RandFakeAtUri("app.bsky.feed.post", "nsfw-video")
 	nsfwArtVideoPost := indigoTest.RandFakeAtUri("app.bsky.feed.post", "nsfw-art-video")
 	artVideoPost := indigoTest.RandFakeAtUri("app.bsky.feed.post", "art-video")
+	oldPost := indigoTest.RandFakeAtUri("app.bsky.feed.post", "old-post")
+
+	now := time.Now()
 
 	for _, opts := range []store.CreatePostOpts{
 		{
 			URI:      fursuitPost,
 			Hashtags: []string{"fursuit"},
 			HasMedia: true,
+		},
+		{
+			URI:       oldPost,
+			ActorDID:  furry.DID(),
+			IndexedAt: now.Add(-time.Hour * 24 * 8),
+			HasMedia:  true,
 		},
 		{
 			URI:      murrsuitPost,
@@ -117,6 +126,9 @@ func TestGenerator(t *testing.T) {
 		}
 		if opts.Hashtags == nil {
 			opts.Hashtags = []string{}
+		}
+		if opts.IndexedAt.IsZero() {
+			opts.IndexedAt = now
 		}
 		require.NoError(t, harness.Store.CreatePost(ctx, opts))
 	}

--- a/store/gen/candidate_posts.sql.go
+++ b/store/gen/candidate_posts.sql.go
@@ -108,6 +108,7 @@ WHERE
     )
     -- Remove posts newer than the cursor timestamp
     AND (cp.indexed_at < $7)
+    AND cp.indexed_at > NOW() - INTERVAL '7 day'
 ORDER BY
     cp.indexed_at DESC
 LIMIT $8
@@ -243,6 +244,7 @@ WHERE
         ROW(ph.score, ph.uri)
         < ROW(($8)::REAL, ($9)::TEXT)
     )
+    AND cp.indexed_at > NOW() - INTERVAL '7 day'
 ORDER BY
     ph.score DESC, ph.uri DESC
 LIMIT $10

--- a/store/queries/candidate_posts.sql
+++ b/store/queries/candidate_posts.sql
@@ -74,6 +74,7 @@ WHERE
     )
     -- Remove posts newer than the cursor timestamp
     AND (cp.indexed_at < sqlc.arg(cursor_timestamp))
+    AND cp.indexed_at > NOW() - INTERVAL '7 day'
 ORDER BY
     cp.indexed_at DESC
 LIMIT sqlc.arg(_limit);
@@ -136,6 +137,7 @@ WHERE
         ROW(ph.score, ph.uri)
         < ROW((sqlc.arg(after_score))::REAL, (sqlc.arg(after_uri))::TEXT)
     )
+    AND cp.indexed_at > NOW() - INTERVAL '7 day'
 ORDER BY
     ph.score DESC, ph.uri DESC
 LIMIT sqlc.arg(_limit);


### PR DESCRIPTION
This enforces that posts on all feeds are younger than 7 full days.