### PR TITLE
Include video posts in art feeds

### DIFF
--- a/feed/feed.go
+++ b/feed/feed.go
@@ -568,6 +568,7 @@ func ServiceWithDefaultFeeds(pgxStore *store.PGXStore) *Service {
 		generatorOpts: generatorOpts{
 			DisallowedHashtags: defaultDisallowedHashtags,
 			HasVideo:           tristate.True,
+			HasMedia:           tristate.False,
 			IsNSFW:             tristate.True,
 		},
 	}))
@@ -579,6 +580,7 @@ func ServiceWithDefaultFeeds(pgxStore *store.PGXStore) *Service {
 		generatorOpts: generatorOpts{
 			DisallowedHashtags: defaultDisallowedHashtags,
 			HasVideo:           tristate.True,
+			HasMedia:           tristate.False,
 			IsNSFW:             tristate.True,
 		},
 	}))

--- a/feed/feed_test.go
+++ b/feed/feed_test.go
@@ -185,7 +185,7 @@ func TestGenerator(t *testing.T) {
 						HasMedia:           tristate.True,
 					},
 				},
-				expectedPosts: []string{artPost, nsfwArtPost, nsfwLabelledPost},
+				expectedPosts: []string{artPost, nsfwArtPost, nsfwLabelledPost, artVideoPost, nsfwArtVideoPost},
 			},
 			{
 				name: "nsfw only art",
@@ -196,13 +196,14 @@ func TestGenerator(t *testing.T) {
 						HasMedia: tristate.True,
 					},
 				},
-				expectedPosts: []string{nsfwArtPost, nsfwLabelledPost},
+				expectedPosts: []string{nsfwArtPost, nsfwLabelledPost, nsfwArtVideoPost},
 			},
 			{
 				name: "pinned post",
 				opts: chronologicalGeneratorOpts{
 					generatorOpts: generatorOpts{
 						Hashtags: []string{"placeholder"},
+						HasMedia: tristate.False,
 					},
 					PinnedDIDs: []string{pinnedFurry.DID()},
 				},
@@ -214,6 +215,7 @@ func TestGenerator(t *testing.T) {
 					generatorOpts: generatorOpts{
 						Hashtags: []string{},
 						HasVideo: tristate.True,
+						HasMedia: tristate.False,
 					},
 				},
 				expectedPosts: []string{videoPost, nsfwVideoPost, artVideoPost, nsfwArtVideoPost},
@@ -224,6 +226,7 @@ func TestGenerator(t *testing.T) {
 					generatorOpts: generatorOpts{
 						IsNSFW:   tristate.True,
 						HasVideo: tristate.True,
+						HasMedia: tristate.False,
 					},
 				},
 				expectedPosts: []string{nsfwVideoPost, nsfwArtVideoPost},
@@ -315,7 +318,7 @@ func TestGenerator(t *testing.T) {
 						HasMedia:           tristate.True,
 					},
 				},
-				expectedPosts: []string{artPost, nsfwArtPost, nsfwLabelledPost},
+				expectedPosts: []string{artPost, nsfwArtPost, nsfwLabelledPost, artVideoPost, nsfwArtVideoPost},
 			},
 			{
 				name: "nsfw only art",
@@ -327,7 +330,7 @@ func TestGenerator(t *testing.T) {
 						HasMedia: tristate.True,
 					},
 				},
-				expectedPosts: []string{nsfwArtPost, nsfwLabelledPost},
+				expectedPosts: []string{nsfwArtPost, nsfwLabelledPost, nsfwArtVideoPost},
 			},
 			{
 				name: "all videos",
@@ -336,6 +339,7 @@ func TestGenerator(t *testing.T) {
 					generatorOpts: generatorOpts{
 						Hashtags: []string{},
 						HasVideo: tristate.True,
+						HasMedia: tristate.False,
 					},
 				},
 				expectedPosts: []string{videoPost, nsfwVideoPost, artVideoPost, nsfwArtVideoPost},
@@ -348,6 +352,7 @@ func TestGenerator(t *testing.T) {
 						Hashtags: []string{},
 						IsNSFW:   tristate.True,
 						HasVideo: tristate.True,
+						HasMedia: tristate.False,
 					},
 				},
 				expectedPosts: []string{nsfwVideoPost, nsfwArtVideoPost},

--- a/store/gen/candidate_posts.sql.go
+++ b/store/gen/candidate_posts.sql.go
@@ -82,15 +82,17 @@ WHERE
                 COALESCE($2::TEXT [], '{}') = '{}'
                 OR NOT $2::TEXT [] && cp.hashtags
             )
-            -- Match has_media status. If unspecified, do not filter.
             AND (
-                $3::BOOLEAN IS NULL
-                OR COALESCE(cp.has_media, FALSE) = $3
-            )
-            -- Match has_video status. If unspecified, do not filter.
-            AND (
-                $4::BOOLEAN IS NULL
-                OR COALESCE(cp.has_video, FALSE) = $4
+                -- Match has_media status. If unspecified, do not filter.
+                (
+                    $3::BOOLEAN IS NULL
+                    OR COALESCE(cp.has_media, FALSE) = $3
+                )
+                -- Match has_video status. If unspecified, do not filter.
+                OR (
+                    $4::BOOLEAN IS NULL
+                    OR COALESCE(cp.has_video, FALSE) = $4
+                )
             )
             -- Filter by NSFW status. If unspecified, do not filter.
             AND (
@@ -216,15 +218,17 @@ WHERE
         COALESCE($4::TEXT [], '{}') = '{}'
         OR NOT $4::TEXT [] && cp.hashtags
     )
-    -- Match has_media status. If unspecified, do not filter.
     AND (
-        $5::BOOLEAN IS NULL
-        OR COALESCE(cp.has_media, FALSE) = $5
-    )
-    -- Match has_video status. If unspecified, do not filter.
-    AND (
-        $6::BOOLEAN IS NULL
-        OR COALESCE(cp.has_video, FALSE) = $6
+        -- Match has_media status. If unspecified, do not filter.
+        (
+            $5::BOOLEAN IS NULL
+            OR COALESCE(cp.has_media, FALSE) = $5
+        )
+        -- Match has_video status. If unspecified, do not filter.
+        OR (
+            $6::BOOLEAN IS NULL
+            OR COALESCE(cp.has_video, FALSE) = $6
+        )
     )
     -- Filter by NSFW status. If unspecified, do not filter.
     AND (

--- a/store/queries/candidate_posts.sql
+++ b/store/queries/candidate_posts.sql
@@ -48,15 +48,17 @@ WHERE
                 COALESCE(sqlc.narg(disallowed_hashtags)::TEXT [], '{}') = '{}'
                 OR NOT sqlc.narg(disallowed_hashtags)::TEXT [] && cp.hashtags
             )
-            -- Match has_media status. If unspecified, do not filter.
             AND (
-                sqlc.narg(has_media)::BOOLEAN IS NULL
-                OR COALESCE(cp.has_media, FALSE) = sqlc.narg(has_media)
-            )
-            -- Match has_video status. If unspecified, do not filter.
-            AND (
-                sqlc.narg(has_video)::BOOLEAN IS NULL
-                OR COALESCE(cp.has_video, FALSE) = sqlc.narg(has_video)
+                -- Match has_media status. If unspecified, do not filter.
+                (
+                    sqlc.narg(has_media)::BOOLEAN IS NULL
+                    OR COALESCE(cp.has_media, FALSE) = sqlc.narg(has_media)
+                )
+                -- Match has_video status. If unspecified, do not filter.
+                OR (
+                    sqlc.narg(has_video)::BOOLEAN IS NULL
+                    OR COALESCE(cp.has_video, FALSE) = sqlc.narg(has_video)
+                )
             )
             -- Filter by NSFW status. If unspecified, do not filter.
             AND (
@@ -109,15 +111,17 @@ WHERE
         COALESCE(sqlc.narg(disallowed_hashtags)::TEXT [], '{}') = '{}'
         OR NOT sqlc.narg(disallowed_hashtags)::TEXT [] && cp.hashtags
     )
-    -- Match has_media status. If unspecified, do not filter.
     AND (
-        sqlc.narg(has_media)::BOOLEAN IS NULL
-        OR COALESCE(cp.has_media, FALSE) = sqlc.narg(has_media)
-    )
-    -- Match has_video status. If unspecified, do not filter.
-    AND (
-        sqlc.narg(has_video)::BOOLEAN IS NULL
-        OR COALESCE(cp.has_video, FALSE) = sqlc.narg(has_video)
+        -- Match has_media status. If unspecified, do not filter.
+        (
+            sqlc.narg(has_media)::BOOLEAN IS NULL
+            OR COALESCE(cp.has_media, FALSE) = sqlc.narg(has_media)
+        )
+        -- Match has_video status. If unspecified, do not filter.
+        OR (
+            sqlc.narg(has_video)::BOOLEAN IS NULL
+            OR COALESCE(cp.has_video, FALSE) = sqlc.narg(has_video)
+        )
     )
     -- Filter by NSFW status. If unspecified, do not filter.
     AND (


### PR DESCRIPTION
This changes the query to check for has_media and has_video with logical OR, so the default `tristate.Maybe` is accurate.

For example, right now, if you set `HasMedia: tristate.True`, `HasVideo` will implicitly always be `tristate.False` so no videos will show on that feed.



## Before

| `HasMedia` | `HasVideo` | Media posts? | Video posts? | Other posts? |
| ---------- | ---------- | ------------ | ------------ | ------------ |
| Maybe      | Maybe      | ✅           | ✅           | ✅           |
| Maybe      | False      | ✅           | ❌           | ✅           |
| False      | Maybe      | ❌           | ✅           | ✅           |
| False      | False      | ❌           | ❌           | ✅           |
| Maybe      | True       | ❌           | ✅           | ❌           |
| False      | True       | ❌           | ✅           | ❌           |
| True       | Maybe      | ✅           | ❌           | ❌           |
| True       | False      | ✅           | ❌           | ❌           |
| True       | True       | ❌           | ❌           | ❌           |

## After

| `HasMedia` | `HasVideo` | Media posts? | Video posts? | Other posts? |
| ---------- | ---------- | ------------ | ------------ | ------------ |
| Maybe      | Maybe      | ✅           | ✅           | ✅           |
| Maybe      | False      | ✅           | ❌           | ✅           |
| False      | Maybe      | ❌           | ✅           | ✅           |
| False      | False      | ❌           | ❌           | ✅           |
| Maybe      | True       | ✅ (change)  | ✅           | ❌           |
| False      | True       | ❌           | ✅           | ❌           |
| True       | Maybe      | ✅           | ✅ (change)  | ❌           |
| True       | False      | ✅           | ❌           | ❌           |
| True       | True       | ❌           | ❌           | ❌           |
