### PR TITLE
Allow leading '@' in login identifier

### DIFF
--- a/web/admin/app.vue
+++ b/web/admin/app.vue
@@ -26,7 +26,7 @@ async function login() {
   error.value = null;
 
   const isSignedIn = await auth
-    .login(identifier.value, password.value)
+    .login(identifier.value?.replace(/^@/, ""), password.value)
     .catch((error) => ({ error }));
 
   if (isSignedIn.error) {


### PR DESCRIPTION
This makes the login more lenient by allowing users to login with their Bluesky handle prefixed with an '@' character, like it is shown in the Bluesky app.