### PR TITLE
Update empty profile queue category

### DIFF
--- a/web/admin/pages/index.vue
+++ b/web/admin/pages/index.vue
@@ -11,7 +11,7 @@ const heldBack = ref<Actor[]>([]);
 
 const actorProfiles = ref<ProfileViewDetailed[]>([]);
 const randomActor = ref<Actor>();
-const currentQueue = ref<keyof (typeof queues)["value"]>("All");
+const currentQueue = ref<keyof typeof queues["value"]>("All");
 
 const error = ref<string>();
 
@@ -26,7 +26,7 @@ const queues = computed(() => ({
     const profile = didToProfile(actor.did);
     if (!profile) return false;
 
-    return !profile.avatar && !profile.description;
+    return !profile.displayName && !profile.description && !profile.postsCount;
   }),
   "Held back": heldBack.value,
 }));


### PR DESCRIPTION
This updates the **Empty profiles** queue category to use the post count and display name instead of avatar, since every new Bluesky account now has a default avatar. (I confirmed this with a new test account.)

On the current queue:

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/e0dd5196-c816-469d-a213-9c7f222941fd) | ![image](https://github.com/user-attachments/assets/3ceba3db-8424-4cfd-a741-b8f422c9eff1) |