### PR TITLE
Fix audit log error is not propagated

### DIFF
--- a/web/admin/components/user/profile.vue
+++ b/web/admin/components/user/profile.vue
@@ -49,20 +49,20 @@ await refresh();
 
 <template>
   <div>
+    <user-card
+      class="mb-5"
+      :did="subject?.did || props.did"
+      :pending="pending"
+      :variant="variant"
+      @next="handleNext"
+    />
     <shared-card v-if="error" variant="error">{{ error }}</shared-card>
-    <div v-else>
-      <user-card
-        class="mb-5"
-        :did="subject?.did || props.did"
-        :pending="pending"
-        :variant="variant"
-        @next="handleNext"
-      />
-      <user-audit-log
-        ref="auditLog"
-        :subject="subject"
-        :did="subject?.did || props.did"
-      />
-    </div>
+    <user-audit-log
+      v-else
+      ref="auditLog"
+      :subject="subject"
+      :did="subject?.did || props.did"
+      @error="error = $event"
+    />
   </div>
 </template>


### PR DESCRIPTION
This fixes an accidentally silenced error when the audit log fails to load on a user page.

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/1fb41b15-073c-47c9-b249-9b813464fdcf) | ![image](https://github.com/user-attachments/assets/c5c1b98d-1b76-43fb-9f0a-742fd630c495) |