### PR TITLE
Fix user tooltip overflow

### DIFF
--- a/web/admin/components/shared/user-tooltip.vue
+++ b/web/admin/components/shared/user-tooltip.vue
@@ -22,7 +22,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <shared-card no-padding class="absolute bottom-2.5 w-[200px] bg-slate-800">
+  <shared-card no-padding class="absolute bottom-2.5 w-[270px] bg-slate-800">
     <div v-if="loading" class="py-1.5 px-2">Loading...</div>
     <template v-else>
       <div
@@ -36,7 +36,7 @@ onMounted(async () => {
           not-rounded
           class="rounded-lg"
         />
-        <div>
+        <div class="flex flex-col min-w-0">
           <div class="truncate">{{ profile.displayName }}</div>
           <div class="text-muted truncate">@{{ profile.handle }}</div>
         </div>


### PR DESCRIPTION
This fixes a bug that long user names or handles overflow the user tooltip.

This also increases the width of the user tooltip from 200px to 270px to make long user names, which would now be cut off, easier to read.

## Screenshots

(This is simulated.)

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/ae1e37c3-123d-4934-a8c2-a95215bacab1) | ![image](https://github.com/user-attachments/assets/08d53baa-b79b-4cf8-bcdf-1911f6702aa4) |