### PR TITLE
Fix user tooltip doesn't load for non-furries

### DIFF
--- a/web/admin/components/shared/user-tooltip.vue
+++ b/web/admin/components/shared/user-tooltip.vue
@@ -15,8 +15,8 @@ const actor = ref<Actor>();
 onMounted(async () => {
   profile.value = await getProfile(props.did);
   const api = await useAPI();
-  const resp = await api.getActor({ did: props.did });
-  actor.value = resp.actor;
+  const resp = await api.getActor({ did: props.did }).catch(() => null);
+  actor.value = resp?.actor;
   loading.value = false;
 });
 </script>


### PR DESCRIPTION
This fixes a bug where if you hover over a handle and the account is not tracked by us, an uncaught exception would cause the tooltip to be stuck in 'Loading...' forever.
