### PR TITLE
Style quotes and paragraphs in audit log comments

### DIFF
--- a/web/admin/components/shared/markdown.vue
+++ b/web/admin/components/shared/markdown.vue
@@ -34,4 +34,13 @@ const renderedMarkdown = computed(() => {
 .markdown >>> table {
   @apply hidden;
 }
+
+.markdown >>> blockquote {
+  @apply pl-2 border-l-4 border-gray-400 dark:border-gray-700;
+}
+
+.markdown >>> p:not(:last-child),
+.markdown >>> blockquote:not(:last-child) {
+  @apply mb-2;
+}
 </style>


### PR DESCRIPTION
This adds spacing between paragraphs and visually distinguishes block quotes from paragraphs in audit log comments.

## Screenshots

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/0fa6b206-51c3-4c9a-a83b-a0f4b4409d08) | ![image](https://github.com/user-attachments/assets/3b8441e0-c3a1-4731-a8b8-4fc7295f7d55) |