### PR TITLE
Skip modal when rejecting deleted profiles

### DIFF
--- a/web/admin/components/user/queue-actions.vue
+++ b/web/admin/components/user/queue-actions.vue
@@ -78,6 +78,14 @@ async function holdBack() {
   $emit("next");
   loading.value = false;
 }
+
+function promptReject() {
+  if (props.rejectOnly) {
+    reject("Profile no longer exists");
+    return;
+  }
+  showRejectModal.value = true;
+}
 </script>
 
 <template>
@@ -106,7 +114,7 @@ async function holdBack() {
     :class="{ 'text-sm': small }"
     class="py-0.5 max-md:py-1 max-md:px-3 px-2 mr-1 bg-red-500 dark:bg-red-600 hover:bg-red-600 dark:hover:bg-red-700 disabled:bg-red-400 disabled:dark:bg-red-500 rounded-lg disabled:cursor-not-allowed"
     :disabled="loading"
-    @click="showRejectModal = true"
+    @click="promptReject"
   >
     Reject
   </button>


### PR DESCRIPTION
This simplifies the rejection of deleted profiles by skipping the
rejection modal and directly rejecting the account with the reason
'Profile no longer exists'.
