### PR TITLE
Require word boundary after 'cat' in furry detector

### DIFF
--- a/web/admin/lib/furry-detector.ts
+++ b/web/admin/lib/furry-detector.ts
@@ -48,7 +48,7 @@ export function isProbablyFurry(profile?: ProfileViewMinimal): boolean {
     "fluffy",
     "dog",
     "deer",
-    "cat",
+    /cat\b/,
     "wolf",
     "dragon",
     /\bsnep\b/,


### PR DESCRIPTION
See [this Discord message](https://discord.com/channels/1107564504021209189/1125845147649847420/1305292546947158142) (internal).
