### PR TITLE
Limit wanted collections on jetstream

### DIFF
--- a/ingester/ingester.go
+++ b/ingester/ingester.go
@@ -83,6 +83,12 @@ func (fi *FirehoseIngester) Start(ctx context.Context) (err error) {
 
 	jsCfg := jsclient.DefaultClientConfig()
 	jsCfg.WebsocketURL = fi.jetstreamURL
+	jsCfg.WantedCollections = []string{
+		"app.bsky.actor.profile",
+		"app.bsky.feed.like",
+		"app.bsky.feed.post",
+		"app.bsky.graph.follow",
+	}
 
 	var activeCursor atomic.Int64
 	sched := jsparallel.NewScheduler(


### PR DESCRIPTION
This limits the wantedCollections on jetstream to just the ones we need,
so backfilling is faster and ingesting is more efficient.
