### PR TITLE
Hide posts with created_at older than 7 days

### DIFF
--- a/feed/feed_test.go
+++ b/feed/feed_test.go
@@ -134,6 +134,9 @@ func TestGenerator(t *testing.T) {
 		if opts.IndexedAt.IsZero() {
 			opts.IndexedAt = now
 		}
+		if opts.CreatedAt.IsZero() {
+			opts.CreatedAt = now
+		}
 		require.NoError(t, harness.Store.CreatePost(ctx, opts))
 	}
 

--- a/store/gen/candidate_posts.sql.go
+++ b/store/gen/candidate_posts.sql.go
@@ -118,6 +118,7 @@ WHERE
     -- Remove posts newer than the cursor timestamp
     AND (cp.indexed_at < $5)
     AND cp.indexed_at > NOW() - INTERVAL '7 day'
+    AND cp.created_at > NOW() - INTERVAL '7 day'
 ORDER BY
     cp.indexed_at DESC
 LIMIT $6
@@ -261,6 +262,7 @@ WHERE
         < ROW(($6)::REAL, ($7)::TEXT)
     )
     AND cp.indexed_at > NOW() - INTERVAL '7 day'
+    AND cp.created_at > NOW() - INTERVAL '7 day'
 ORDER BY
     ph.score DESC, ph.uri DESC
 LIMIT $8

--- a/store/migrations/000024_add_post_created_at_index.down.sql
+++ b/store/migrations/000024_add_post_created_at_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX candidate_posts_created_at_idx;

--- a/store/migrations/000024_add_post_created_at_index.up.sql
+++ b/store/migrations/000024_add_post_created_at_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX candidate_posts_created_at_idx ON public.candidate_posts (created_at);

--- a/store/queries/candidate_posts.sql
+++ b/store/queries/candidate_posts.sql
@@ -84,6 +84,7 @@ WHERE
     -- Remove posts newer than the cursor timestamp
     AND (cp.indexed_at < sqlc.arg(cursor_timestamp))
     AND cp.indexed_at > NOW() - INTERVAL '7 day'
+    AND cp.created_at > NOW() - INTERVAL '7 day'
 ORDER BY
     cp.indexed_at DESC
 LIMIT sqlc.arg(_limit);
@@ -156,6 +157,7 @@ WHERE
         < ROW((sqlc.arg(after_score))::REAL, (sqlc.arg(after_uri))::TEXT)
     )
     AND cp.indexed_at > NOW() - INTERVAL '7 day'
+    AND cp.created_at > NOW() - INTERVAL '7 day'
 ORDER BY
     ph.score DESC, ph.uri DESC
 LIMIT sqlc.arg(_limit);


### PR DESCRIPTION
This hides posts with the `created_at` being older than 7 days (in addition to the existing 7 day `indexed_at` age rule) in the feeds. I’ve seen a lot of people backfill their old posts, and we don’t want to show them on the feeds since users are only adding them to give their accounts a history. Otherwise they would post them as new posts like some artists do by reposting old art.