### PR TITLE
Speed up didToProfile in large queues

### DIFF
--- a/web/admin/pages/index.vue
+++ b/web/admin/pages/index.vue
@@ -15,6 +15,16 @@ const currentQueue = ref<keyof typeof queues["value"]>("All");
 
 const error = ref<string>();
 
+const actorProfilesMap = computed(() => {
+  const map = new Map<string, ProfileViewDetailed>();
+
+  for (const profile of actorProfiles.value) {
+    map.set(profile.did, profile);
+  }
+
+  return map;
+});
+
 const queues = computed(() => ({
   All: actors.value,
   "Probably furry": actors.value.filter((actor) => {
@@ -59,7 +69,7 @@ const nextActor = async () => {
 await nextActor();
 
 function didToProfile(did: string): ProfileViewDetailed | undefined {
-  return actorProfiles.value.find((p) => p.did === did);
+  return actorProfilesMap.value.get(did);
 }
 
 function selectRandomActor() {


### PR DESCRIPTION
This speeds up the `didToProfile` helper on the queue page if the queue
is large (say over 500 accounts). I’m not quite sure why the current
solution is this slow (up to 3s to rerender) since we should only be
looking at 2.25 million lookups maxium in a queue of n = 1500.

Generating the map initially takes around 2ms and any lookups via
`didToProfile` go down from around 40ms to <0.2ms.
