### PR TITLE
Fix user without avatar is shows loading animation

### DIFF
--- a/web/admin/components/shared/avatar.vue
+++ b/web/admin/components/shared/avatar.vue
@@ -40,7 +40,7 @@ watch(() => props.did, updateUrl);
     alt=""
   />
   <div
-    v-else-if="loading"
+    v-else-if="loading && did && hasAvatar"
     class="loading-flash"
     :style="{ height: `${size}px`, width: `${size}px` }"
   ></div>


### PR DESCRIPTION
This fixes a bug where if an account has no avatar, it will forever show the loading animation.

## Screenshots

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/3c769ac7-8220-4c54-962a-05ab521fe6db) | ![image](https://github.com/user-attachments/assets/a1c7b934-6f24-4900-9393-4b8952fb49a8) |
