### PR TITLE
Mark auto-generated files as auto generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.sql.go linguist-generated=true
+*.pb.go linguist-generated=true
+web/proto/bff/* linguist-generated=true
+


### PR DESCRIPTION
This makes diffs easier to read, see the docs:

https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github
