### PR TITLE
Remove #furcon tag from FC feed

### DIFF
--- a/feed/feed.go
+++ b/feed/feed.go
@@ -446,8 +446,7 @@ func ServiceWithDefaultFeeds(pgxStore *store.PGXStore) *Service {
 	}, chronologicalGenerator(chronologicalGeneratorOpts{
 		generatorOpts: generatorOpts{
 			Hashtags: []string{
-				"fc", "fc25", "fc2025",
-				"furcon", "furcon25", "furcon2025",
+				"fc", "fc25", "fc2025", "furcon25", "furcon2025",
 				"furtherconfusion", "furtherconfusion25", "furtherconfusion2025",
 			},
 			DisallowedHashtags: defaultDisallowedHashtags,


### PR DESCRIPTION
This fixes that posts from other cons show up on the FC feed due to the
overly generic #furcon tag.

See https://discord.com/channels/1107564504021209189/1315428356824502443
(internal).
