### PR TITLE
Make video feeds use native content mode

### DIFF
--- a/bluesky/pds_client.go
+++ b/bluesky/pds_client.go
@@ -249,7 +249,7 @@ func (c *PDSClient) DeleteRecord(
 		return fmt.Errorf("get xrpc client: %w", err)
 	}
 
-	if err := atproto.RepoDeleteRecord(ctx, xc, &atproto.RepoDeleteRecord_Input{
+	if _, err := atproto.RepoDeleteRecord(ctx, xc, &atproto.RepoDeleteRecord_Input{
 		Collection: uri.Collection,
 		Repo:       uri.Did,
 		Rkey:       uri.Rkey,

--- a/cmd/bffctl/bsky.go
+++ b/cmd/bffctl/bsky.go
@@ -55,13 +55,20 @@ func bskyCmd(log *slog.Logger, env *environment) *cli.Command {
 						meta := meta
 
 						log.Info("upserting feed", slog.String("rkey", meta.ID))
-						err = client.PutRecord(cctx.Context, "app.bsky.feed.generator", meta.ID, &bsky.FeedGenerator{
+						gen := &bsky.FeedGenerator{
 							Avatar:      blob,
 							Did:         fmt.Sprintf("did:web:%s", hostname),
 							CreatedAt:   bluesky.FormatTime(time.Now().UTC()),
 							Description: &meta.Description,
 							DisplayName: meta.DisplayName,
-						})
+						}
+
+						if meta.VideoOnly {
+							var contentModeVideo = "app.bsky.feed.defs#contentModeVideo"
+							gen.ContentMode = &contentModeVideo
+						}
+
+						err = client.PutRecord(cctx.Context, "app.bsky.feed.generator", meta.ID, gen)
 						if err != nil {
 							return fmt.Errorf("putting feed record: %w", err)
 						}

--- a/feed/feed.go
+++ b/feed/feed.go
@@ -33,6 +33,8 @@ type Meta struct {
 	Priority int32
 	// TODO: Categories
 	// TODO: "Parents"
+
+	VideoOnly bool
 }
 
 type feed struct {
@@ -555,6 +557,7 @@ func ServiceWithDefaultFeeds(pgxStore *store.PGXStore) *Service {
 		DisplayName: "🐾 Hot videos",
 		Description: "Furry\nHottest video posts by furries across Bluesky. Contains a mix of SFW and NSFW content.\n\nJoin the furry feeds by following @furryli.st",
 		Priority:    100,
+		VideoOnly:   true,
 	}, preScoredGenerator(preScoredGeneratorOpts{
 		Alg: "classic",
 		generatorOpts: generatorOpts{
@@ -566,6 +569,7 @@ func ServiceWithDefaultFeeds(pgxStore *store.PGXStore) *Service {
 		ID:          "video-new",
 		DisplayName: "🐾 New videos",
 		Description: "Furry\nLatest video posts by furries across Bluesky. Contains a mix of SFW and NSFW content.\n\nJoin the furry feeds by following @furryli.st",
+		VideoOnly:   true,
 	}, chronologicalGenerator(chronologicalGeneratorOpts{
 		generatorOpts: generatorOpts{
 			DisallowedHashtags: defaultDisallowedHashtags,
@@ -577,6 +581,7 @@ func ServiceWithDefaultFeeds(pgxStore *store.PGXStore) *Service {
 		DisplayName: "🐾 Hot videos 🌙",
 		Description: "Furry\nHottest NSFW video posts by furries across Bluesky. Contains only NSFW content.\n\nJoin the furry feeds by following @furryli.st",
 		Priority:    100,
+		VideoOnly:   true,
 	}, preScoredGenerator(preScoredGeneratorOpts{
 		Alg: "classic",
 		generatorOpts: generatorOpts{
@@ -589,6 +594,7 @@ func ServiceWithDefaultFeeds(pgxStore *store.PGXStore) *Service {
 		ID:          "video-new-nsfw",
 		DisplayName: "🐾 New videos 🌙",
 		Description: "Furry\nLatest NSFW video posts by furries across Bluesky. Contains only NSFW content.\n\nJoin the furry feeds by following @furryli.st",
+		VideoOnly:   true,
 	}, chronologicalGenerator(chronologicalGeneratorOpts{
 		generatorOpts: generatorOpts{
 			DisallowedHashtags: defaultDisallowedHashtags,

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go/cloudsqlconn v1.5.2
 	connectrpc.com/connect v1.11.0
 	connectrpc.com/otelconnect v0.5.0
-	github.com/bluesky-social/indigo v0.0.0-20240908200721-58e6cb486877
+	github.com/bluesky-social/indigo v0.0.0-20250119185343-e1d4639a0604
 	github.com/bluesky-social/jetstream v0.0.0-20241031234625-0ab10bd041fe
 	github.com/docker/go-connections v0.4.0
 	github.com/golang-migrate/migrate/v4 v4.16.2
@@ -23,7 +23,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.21.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.21.0
 	github.com/urfave/cli/v2 v2.26.0
-	github.com/whyrusleeping/cbor-gen v0.1.3-0.20240904181319-8dc02b38228c
+	github.com/whyrusleeping/cbor-gen v0.2.1-0.20241030202151-b7a6831be65e
 	go.opentelemetry.io/contrib/detectors/gcp v1.21.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1
 	go.opentelemetry.io/otel v1.21.0
@@ -42,6 +42,7 @@ require (
 	github.com/DataDog/zstd v1.5.5 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/RussellLuo/slidingwindow v0.0.0-20200528002341-535bb99d338b // indirect
+	github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874 // indirect
 	github.com/carlmjohnson/versioninfo v0.22.5 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/cockroachdb/errors v1.11.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -74,10 +74,12 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/bluesky-social/indigo v0.0.0-20240908200721-58e6cb486877 h1:oPM+7BOEEPi0XZ8ucya3wFnpF7pcRHo1TzvgQvCsvsM=
-github.com/bluesky-social/indigo v0.0.0-20240908200721-58e6cb486877/go.mod h1:Zx9nSWgd/FxMenkJW07VKnzspxpHBdPrPmS+Fspl2I0=
+github.com/bluesky-social/indigo v0.0.0-20250119185343-e1d4639a0604 h1:jnIHdRCkWYJYAGLf6JmdSF7q+80xf7seC5M3uozik0o=
+github.com/bluesky-social/indigo v0.0.0-20250119185343-e1d4639a0604/go.mod h1:UPvCalsPWViUSB6t11u6jg5lF1kLLsaX5t3ybzTSyeE=
 github.com/bluesky-social/jetstream v0.0.0-20241031234625-0ab10bd041fe h1:jduuyDfsiwWrPiN7psqDehepl68uxQ4UYCIgoqb1D4o=
 github.com/bluesky-social/jetstream v0.0.0-20241031234625-0ab10bd041fe/go.mod h1:WiYEeyJSdUwqoaZ71KJSpTblemUCpwJfh5oVXplK6T4=
+github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874 h1:N7oVaKyGp8bttX0bfZGmcGkjz7DLQXhAn3DNd3T0ous=
+github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874/go.mod h1:r5xuitiExdLAJ09PR7vBVENGvp4ZuTBeWTGtxuX3K+c=
 github.com/brianvoe/gofakeit/v6 v6.25.0 h1:ZpFjktOpLZUeF8q223o0rUuXtA+m5qW5srjvVi+JkXk=
 github.com/brianvoe/gofakeit/v6 v6.25.0/go.mod h1:Xj58BMSnFqcn/fAQeSK+/PLtC5kSb7FJIq4JyGa8vEs=
 github.com/carlmjohnson/versioninfo v0.22.5 h1:O00sjOLUAFxYQjlN/bzYTuZiS0y6fWDQjMRvwtKgwwc=
@@ -640,8 +642,8 @@ github.com/warpfork/go-wish v0.0.0-20220906213052-39a1cc7a02d0 h1:GDDkbFiaK8jsSD
 github.com/warpfork/go-wish v0.0.0-20220906213052-39a1cc7a02d0/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=
 github.com/whyrusleeping/cbor v0.0.0-20171005072247-63513f603b11 h1:5HZfQkwe0mIfyDmc1Em5GqlNRzcdtlv4HTNmdpt7XH0=
 github.com/whyrusleeping/cbor v0.0.0-20171005072247-63513f603b11/go.mod h1:Wlo/SzPmxVp6vXpGt/zaXhHH0fn4IxgqZc82aKg6bpQ=
-github.com/whyrusleeping/cbor-gen v0.1.3-0.20240904181319-8dc02b38228c h1:UsxJNcLPfyLyVaA4iusIrsLAqJn/xh36Qgb8emqtXzk=
-github.com/whyrusleeping/cbor-gen v0.1.3-0.20240904181319-8dc02b38228c/go.mod h1:pM99HXyEbSQHcosHc0iW7YFmwnscr+t9Te4ibko05so=
+github.com/whyrusleeping/cbor-gen v0.2.1-0.20241030202151-b7a6831be65e h1:28X54ciEwwUxyHn9yrZfl5ojgF4CBNLWX7LR0rvBkf4=
+github.com/whyrusleeping/cbor-gen v0.2.1-0.20241030202151-b7a6831be65e/go.mod h1:pM99HXyEbSQHcosHc0iW7YFmwnscr+t9Te4ibko05so=
 github.com/whyrusleeping/chunker v0.0.0-20181014151217-fe64bd25879f h1:jQa4QT2UP9WYv2nzyawpKMOCl+Z/jW7djv2/J50lj9E=
 github.com/whyrusleeping/chunker v0.0.0-20181014151217-fe64bd25879f/go.mod h1:p9UJB6dDgdPgMJZs7UjUOdulKyRr9fqkS+6JKAInPy8=
 github.com/whyrusleeping/go-did v0.0.0-20230824162731-404d1707d5d6 h1:yJ9/LwIGIk/c0CdoavpC9RNSGSruIspSZtxG3Nnldic=

--- a/ingester/ingester_test.go
+++ b/ingester/ingester_test.go
@@ -90,7 +90,7 @@ func TestFirehoseIngester(t *testing.T) {
 	t.Cleanup(func() { wsConn.Close() })
 
 	go func() {
-		err := events.HandleRepoStream(ctx, wsConn, scheduler)
+		err := events.HandleRepoStream(ctx, wsConn, scheduler, slog.Default())
 		if err != nil && !strings.Contains(err.Error(), net.ErrClosed.Error()) {
 			require.NoError(t, err)
 		}

--- a/testenv/testenv.go
+++ b/testenv/testenv.go
@@ -96,7 +96,7 @@ func StartHarness(ctx context.Context, t *testing.T) *Harness {
 	pds.Run(t)
 	t.Cleanup(pds.Cleanup)
 
-	relay := indigoTest.MustSetupRelay(t, didr)
+	relay := indigoTest.MustSetupRelay(t, didr, true)
 	relay.Run(t)
 	setTrialHostOnRelay(relay, pds.RawHost())
 


### PR DESCRIPTION
This uses the new `contentMode` property on the FeedGenerator record to support native video feeds for our video-only feeds.

This also upgrades Indigo for that.