### PR TITLE
Include deleted profiles in 'Empty profiles' queue

### DIFF
--- a/web/admin/pages/index.vue
+++ b/web/admin/pages/index.vue
@@ -34,7 +34,7 @@ const queues = computed(() => ({
   }),
   "Empty profiles": actors.value.filter((actor) => {
     const profile = didToProfile(actor.did);
-    if (!profile) return false;
+    if (!profile) return true;
 
     return !profile.displayName && !profile.description && !profile.postsCount;
   }),


### PR DESCRIPTION
This includes deleted profiles in the 'Empty profiles' queue, so they
are easier to reject.

Next step would be auto-rejecting deleted profiles.
