### PR TITLE
Add new 'Likely spam' queue

### DIFF
--- a/web/admin/lib/furry-detector.ts
+++ b/web/admin/lib/furry-detector.ts
@@ -1,4 +1,5 @@
 import { ProfileViewDetailed } from "@atproto/api/dist/client/types/app/bsky/actor/defs";
+import { matchTerms } from "./util";
 
 type ProfileViewMinimal = Pick<ProfileViewDetailed, "displayName"> &
   Pick<ProfileViewDetailed, "description"> &
@@ -81,15 +82,5 @@ export function isProbablyFurry(profile?: ProfileViewMinimal): boolean {
     .map((s) => s.toLowerCase())
     .join(" ");
 
-  for (const term of terms) {
-    if (
-      typeof term === "object"
-        ? description.match(term)
-        : description.includes(term)
-    ) {
-      return true;
-    }
-  }
-
-  return false;
+  return matchTerms(terms, description);
 }

--- a/web/admin/lib/spam-detector.ts
+++ b/web/admin/lib/spam-detector.ts
@@ -1,0 +1,31 @@
+import { matchTerms, ProfileViewMinimal } from "./util";
+
+const FOLLOWS_THRESHOLD = 10_000;
+
+export function isProbablySpam(profile?: ProfileViewMinimal): boolean {
+  if (!profile) {
+    return false;
+  }
+
+  if (!profile.description) {
+    return false;
+  }
+
+  if ((profile.followsCount || 0) > FOLLOWS_THRESHOLD) {
+    return true;
+  }
+
+  const terms = [
+    /#resist(er)?\b/i,
+    /#teamblue\b/i,
+    /#bluecrew\b/i,
+    /\bai artist\b/i,
+    /blue (democrat|crew)/i,
+    /#defenddemocracy\b/i,
+    /\b(ai |to )?prompt\b/i,
+    /(dm|message|e?mail)( me)? (for|to) (removal|remove)/i,
+    /follow\b.+follow back/,
+  ];
+
+  return matchTerms(terms, profile.description);
+}

--- a/web/admin/lib/util.ts
+++ b/web/admin/lib/util.ts
@@ -1,3 +1,10 @@
+import { ProfileViewDetailed } from "@atproto/api/dist/client/types/app/bsky/actor/defs";
+
+export type ProfileViewMinimal = Pick<ProfileViewDetailed, "displayName"> &
+  Pick<ProfileViewDetailed, "description"> &
+  Pick<ProfileViewDetailed, "handle"> &
+  Pick<ProfileViewDetailed, "followsCount">;
+
 export function addSISuffix(number?: number) {
   number = number || 0;
 
@@ -9,4 +16,19 @@ export function addSISuffix(number?: number) {
   }
 
   return `${Math.round(number * 100) / 100}${suffixes[order] || ""}`;
+}
+
+export function matchTerms(
+  terms: (string | RegExp)[],
+  haystack: string
+): boolean {
+  for (const term of terms) {
+    if (
+      typeof term === "object" ? haystack.match(term) : haystack.includes(term)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/web/admin/pages/index.vue
+++ b/web/admin/pages/index.vue
@@ -3,6 +3,7 @@ import { getProfile } from "~/lib/cached-bsky";
 import { isProbablyFurry } from "~/lib/furry-detector";
 import { Actor, ActorStatus } from "../../proto/bff/v1/types_pb";
 import { ProfileViewDetailed } from "@atproto/api/dist/client/types/app/bsky/actor/defs";
+import { isProbablySpam } from "~/lib/spam-detector";
 
 const api = await useAPI();
 
@@ -27,12 +28,17 @@ const actorProfilesMap = computed(() => {
 
 const queues = computed(() => ({
   All: actors.value,
-  "Probably furry": actors.value.filter((actor) => {
+  "Likely furry": actors.value.filter((actor) => {
     const profile = didToProfile(actor.did);
 
     return isProbablyFurry(profile);
   }),
-  "Empty profiles": actors.value.filter((actor) => {
+  "Likely spam": actors.value.filter((actor) => {
+    const profile = didToProfile(actor.did);
+
+    return isProbablySpam(profile);
+  }),
+  Empty: actors.value.filter((actor) => {
     const profile = didToProfile(actor.did);
     if (!profile) return true;
 


### PR DESCRIPTION
This adds a new 'Likely spam' pre-categorized queue to filter out accounts that have more than 10k follows or match some terms often found in accounts that are rejected for spam.

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/da04978d-dbce-414a-a8d4-5cf89041f76f) | ![image](https://github.com/user-attachments/assets/06bf1d8d-6ba4-4349-8e57-400b67fc54a1) |