### PR TITLE
Fix spam detector ignores accounts without description

### DIFF
--- a/web/admin/lib/spam-detector.ts
+++ b/web/admin/lib/spam-detector.ts
@@ -7,12 +7,12 @@ export function isProbablySpam(profile?: ProfileViewMinimal): boolean {
     return false;
   }
 
-  if (!profile.description) {
-    return false;
-  }
-
   if ((profile.followsCount || 0) > FOLLOWS_THRESHOLD) {
     return true;
+  }
+
+  if (!profile.description) {
+    return false;
   }
 
   const terms = [


### PR DESCRIPTION
This fixes a bug where the `followsCount` check is skipped and an account will never be marked as **Likely spam** if it doesn’t have a description.
