### PR TITLE
Link to profiles and URLs in recent posts

### DIFF
--- a/web/admin/components/shared/bsky/text.vue
+++ b/web/admin/components/shared/bsky/text.vue
@@ -1,6 +1,11 @@
 <script lang="ts" setup>
 import { RichTextSegment } from "@atproto/api";
 
+const tooltipAnchor = ref<HTMLDivElement>();
+const tooltipAnchorRect = computed(() =>
+  tooltipAnchor.value?.getBoundingClientRect()
+);
+
 defineProps<{ segment: RichTextSegment }>();
 
 const hovering = ref(false);
@@ -35,11 +40,22 @@ function leave() {
     </nuxt-link>
 
     <div
-      v-if="hovering && segment.mention?.did"
+      ref="tooltipAnchor"
       class="absolute flex left-0 top-0 right-0 w-full"
-    >
-      <shared-user-tooltip :did="segment.mention.did" />
-    </div>
+    ></div>
+    <teleport to="body">
+      <div
+        v-if="hovering && segment.mention?.did"
+        class="absolute flex left-0 top-0 right-0 w-full z-10"
+        :style="{
+          top: `${tooltipAnchorRect?.top}px`,
+          left: `${tooltipAnchorRect?.left}px`,
+          width: `${tooltipAnchorRect?.width}px`,
+        }"
+      >
+        <shared-user-tooltip :did="segment.mention.did" />
+      </div>
+    </teleport>
   </span>
   <span v-else class="whitespace-pre-line">{{ segment.text }}</span>
 </template>

--- a/web/admin/components/user-card.vue
+++ b/web/admin/components/user-card.vue
@@ -72,7 +72,10 @@ await loadProfile();
       @next="next"
       @loading="loading = true"
     />
-    <div class="flex max-md:flex-col gap-3" :class="{ 'loading-flash': loading }">
+    <div
+      class="flex max-md:flex-col gap-3"
+      :class="{ 'loading-flash': loading }"
+    >
       <div class="mb-3 md:w-[50%] card-list h-min flex-1">
         <user-actions :did="data.did" :status="actor?.status" @update="next" />
         <shared-card v-if="data.banner">
@@ -210,7 +213,9 @@ await loadProfile();
                   </span>
                 </div>
                 <div class="flex">
-                  <span class="flex-1">{{ (post.record as any)?.text }}</span>
+                  <shared-bsky-description
+                    :description="(post.record as any)?.text"
+                  />
                   <span
                     v-if="post.embed && 'images' in post.embed"
                     class="w-[25%] h-100"


### PR DESCRIPTION
This reuses the `shared-bsky-description` component for the recent posts
content, so we can directly link to tagged accounts and URLs posted by
users.

This should make it easier to see if an account references accounts that
are already on the list.

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/2b3c45f0-135f-4784-8e3d-3085d873d3d4) | ![image](https://github.com/user-attachments/assets/098679b8-04ce-4c9b-a29b-2e53d5343317) |

## How to test

1. Go to an account that recently posted a link or mention (like `ottr.sh`),
2. scroll down,
3. see the link/mention.