### PR TITLE
Show moderation labels on profiles

### DIFF
--- a/web/admin/components/user-card.vue
+++ b/web/admin/components/user-card.vue
@@ -6,6 +6,7 @@ import { newAgent } from "~/lib/auth";
 import { addSISuffix } from "~/lib/util";
 import { ViewImage } from "@atproto/api/dist/client/types/app/bsky/embed/images";
 import { PostView } from "@atproto/api/dist/client/types/app/bsky/feed/defs";
+import { BlueskyLabel } from "~/composables/useBlueskyLabels";
 
 const props = defineProps<{
   did: string;
@@ -21,7 +22,9 @@ const loading = ref(false);
 const showRolesModal = ref(false);
 const actor = ref<Actor>();
 const data = ref<ProfileViewDetailed>();
+const labels = ref<Array<BlueskyLabel>>([]);
 const loadProfile = async () => {
+  const labelsQuery = useBlueskyLabels(props.did);
   data.value = await getProfile(props.did);
   const response = await api
     .getActor({ did: data.value?.did || props.did })
@@ -35,6 +38,7 @@ const loadProfile = async () => {
         .filter((p) => !p.reply && p.post.author.did === props.did)
         .map((p) => p.post)
     );
+  labels.value = await labelsQuery;
 };
 
 async function next() {
@@ -182,6 +186,27 @@ await loadProfile();
             <icon-square-bubble class="text-muted" :size="18" />
             {{ addSISuffix(data?.postsCount) }}
           </span>
+        </shared-card>
+        <shared-card v-if="labels.length > 0">
+          <ul class="text-sm">
+            <li
+              v-for="label in labels"
+              :key="`${label.src}:${label.val}`"
+              class="flex items-center py-0.5 px-1 border border-gray-300 dark:border-gray-700 rounded-lg w-max"
+            >
+              <shared-avatar
+                :did="label.src"
+                :has-avatar="Boolean(label.labeler.avatar)"
+                :size="20"
+                resize="20x20"
+              />
+              <div>
+                <span class="text-muted text-xs"
+                  >{{ label.labeler.handle }}/</span
+                >{{ label.val }}
+              </div>
+            </li>
+          </ul>
         </shared-card>
         <shared-card v-if="data.description">
           <shared-bsky-description :description="data.description" />

--- a/web/admin/components/user-card.vue
+++ b/web/admin/components/user-card.vue
@@ -199,6 +199,7 @@ await loadProfile();
                 :has-avatar="Boolean(label.labeler.avatar)"
                 :size="20"
                 resize="20x20"
+                class="mr-1"
               />
               <div>
                 <span class="text-muted text-xs"

--- a/web/admin/composables/useBlueskyLabels.ts
+++ b/web/admin/composables/useBlueskyLabels.ts
@@ -1,0 +1,55 @@
+import { ComAtprotoLabelDefs } from "@atproto/api";
+import { ProfileViewDetailed } from "@atproto/api/dist/client/types/app/bsky/actor/defs";
+import { newAgent } from "~/lib/auth";
+import { getProfile } from "~/lib/cached-bsky";
+
+// A list of labelers that are relevant to and likely trusted by the
+// broader Bluesky community and Furrylist user base.
+const labelers: Array<Labeler> = [
+  {
+    did: "did:plc:ar7c4by46qjdydhdevvrndac",
+    name: "bsky-mod",
+  },
+  {
+    did: "did:plc:4ugewi6aca52a62u62jccbl7",
+    name: "asukafield.xyz",
+  },
+  {
+    did: "did:plc:bv2ckchoc76yobfhkrrie4g6",
+    name: "blacksky.app",
+  },
+  {
+    did: "did:plc:lcdcygpdeiittdmdeddxwt4w",
+    name: "laelaps.fyi",
+  },
+];
+
+type Labeler = {
+  did: string;
+  name: string;
+};
+
+export type BlueskyLabel = ComAtprotoLabelDefs.Label & {
+  labeler: ProfileViewDetailed;
+};
+
+export default async function (did: string): Promise<Array<BlueskyLabel>> {
+  const agent = newAgent();
+  let cursor: string | undefined = undefined;
+  const allLabels: Array<BlueskyLabel> = [];
+  do {
+    const labels = await agent.com.atproto.label.queryLabels({
+      uriPatterns: [did],
+      sources: labelers.map((l) => l.did),
+      cursor,
+    });
+    cursor = labels.data.cursor;
+    for (const label of labels.data.labels) {
+      allLabels.push({
+        ...label,
+        labeler: await getProfile(label.src),
+      });
+    }
+  } while (cursor);
+  return allLabels;
+}


### PR DESCRIPTION
This shows moderation labels to the user card from select labelers, which are trusted by the community and broadly align with our rules and values.

This allows us to use labels as reason/prompt to further review profiles to avoid adding accounts that violate our rules to the list.

## Initial labelers

For the first iteration, we’ll start with the following labelers. In the future, we may also want to only show a predefined subset labels.

- [`moderation.bsky.app`](https://bsky.app/profile/did:plc:ar7c4by46qjdydhdevvrndac)
- [`asukafield.xyz`](https://bsky.app/profile/did:plc:4ugewi6aca52a62u62jccbl7)
- [`blacksky.app`](https://bsky.app/profile/did:plc:bv2ckchoc76yobfhkrrie4g6)
- [`laelaps.fyi`](https://bsky.app/profile/did:plc:lcdcygpdeiittdmdeddxwt4w)

## Screenshots

![image](https://github.com/user-attachments/assets/59448420-50a7-4165-97cd-c65aa9d19d3f)
