### PR TITLE
Exclude spam and empty profiles from 'All' queue

### DIFF
--- a/web/admin/lib/queues.ts
+++ b/web/admin/lib/queues.ts
@@ -1,0 +1,60 @@
+import { ProfileViewDetailed } from "@atproto/api/dist/client/types/app/bsky/actor/defs";
+import { isProbablySpam } from "./spam-detector";
+import { isProbablyFurry } from "./furry-detector";
+import { Actor } from "../../proto/bff/v1/types_pb";
+import { UnwrapRef } from "nuxt/dist/app/compat/capi";
+
+type UnwrappedActor = UnwrapRef<Actor>;
+
+export const queueTypes = [
+  "All",
+  "Likely furry",
+  "Likely spam",
+  "Empty",
+  "Held back",
+] as const;
+
+const includeInAll: Array<Category> = ["Likely furry"];
+
+type Category = typeof queueTypes[number];
+
+function categorizeProfile(
+  actor: UnwrappedActor,
+  profile?: ProfileViewDetailed
+): Category {
+  if (actor.heldUntil && actor.heldUntil.toDate() > new Date())
+    return "Held back";
+  if (isProbablySpam(profile)) return "Likely spam";
+  if (isProbablyFurry(profile)) return "Likely furry";
+  if (!profile) return "Empty";
+  if (!profile.displayName && !profile.description && !profile.postsCount)
+    return "Empty";
+
+  return "All";
+}
+
+export function categorizeProfiles(
+  actors: Array<UnwrappedActor>,
+  profiles: Map<string, ProfileViewDetailed>
+): Record<Category, Array<UnwrappedActor>> {
+  const result = {} as Record<Category, Array<UnwrappedActor>>;
+
+  for (const type of queueTypes) {
+    result[type] = [];
+  }
+
+  // Categorize each actor and add to appropriate category
+  for (const actor of actors) {
+    const profile = profiles.get(actor.did);
+    const category = categorizeProfile(actor, profile);
+
+    result[category].push(actor);
+
+    if (includeInAll.includes(category)) {
+      result["All"] = result["All"] || [];
+      result["All"].push(actor);
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
This excludes the `Likely spam` and `Empty` queues from the `All` queue.

## Before

![image](https://github.com/user-attachments/assets/4139b929-b3e8-4a60-9eda-94bb5ff2f365)

## After

![image](https://github.com/user-attachments/assets/2ca6a65b-1d47-4b77-9e87-36491754894f)
