### PR TITLE
Add bulk reject for deleted accounts

### DIFF
--- a/web/admin/lib/util.ts
+++ b/web/admin/lib/util.ts
@@ -32,3 +32,11 @@ export function matchTerms(
 
   return false;
 }
+
+export function chunk<T>(a: Array<T>, max: number): Array<Array<T>> {
+  const result = [];
+  for (let i = 0; i < a.length; i += max) {
+    result.push(a.slice(i, i + max));
+  }
+  return result;
+}


### PR DESCRIPTION
This adds a bulk rejection feature for the empty list to reject all
accounts that no longer exist at the same time.

<img width="423" height="217" alt="image" src="https://github.com/user-attachments/assets/4fe33ac3-e47c-49e2-84f3-6a2fb57f440b" />
