### PR TITLE
refactor(feed): add helper for registering con feeds

### DIFF
--- a/cmd/bffctl/bsky.go
+++ b/cmd/bffctl/bsky.go
@@ -4,18 +4,39 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"time"
+
+	"slices"
 
 	"github.com/bluesky-social/indigo/api/bsky"
 	"github.com/strideynet/bsky-furry-feed/bluesky"
 	"github.com/strideynet/bsky-furry-feed/feed"
 	"github.com/urfave/cli/v2"
+	"go.yaml.in/yaml/v2"
 )
 
 func bskyCmd(log *slog.Logger, env *environment) *cli.Command {
 	return &cli.Command{
 		Name: "bsky",
 		Subcommands: []*cli.Command{
+			{
+				Name:  "list-feeds",
+				Usage: "Lists all feeds",
+				Action: func(ctx *cli.Context) error {
+					feeds := feed.ServiceWithDefaultFeeds(nil)
+					metas := feeds.Metas()
+					slices.SortFunc(metas, func(a, b feed.Meta) int { return strings.Compare(a.ID, b.ID) })
+					for _, meta := range metas {
+						o, err := yaml.Marshal(meta)
+						if err != nil {
+							return err
+						}
+						fmt.Println(string(o))
+					}
+					return nil
+				},
+			},
 			{
 				Name:  "purge-feeds",
 				Usage: "Deletes all feeds associated with the current account",

--- a/feed/con_feed.go
+++ b/feed/con_feed.go
@@ -1,0 +1,129 @@
+package feed
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type conFeed struct {
+	ID        string
+	Name      string
+	MainTags  []string
+	OtherTags []string
+}
+
+// registerChronologicalConFeed registers a con feed (with con- prefix).
+//
+// It appends the current year to the feed name but it doesn't generate the
+// hashtags based on the year.
+func (s *Service) registerChronologicalConFeed(feed conFeed) {
+	var tagList []string
+	for i, tag := range feed.MainTags {
+		if i == len(feed.MainTags)-1 {
+			tagList = append(tagList, "or #"+tag)
+		} else {
+			tagList = append(tagList, "#"+tag)
+		}
+	}
+	var tags string
+	if len(tagList) > 2 {
+		tags = strings.Join(tagList, ", ")
+	} else {
+		tags = strings.Join(tagList, " ")
+	}
+	s.Register(Meta{
+		ID:          "con-" + feed.ID,
+		DisplayName: fmt.Sprintf("%s %s %d", PawEmoji, feed.Name, time.Now().Year()),
+		Description: fmt.Sprintf(
+			"A feed for all things %s! Use %s to include a post in the feed.\n\nJoin the furry feeds by following @furryli.st",
+			feed.Name,
+			tags,
+		),
+	}, chronologicalGenerator(chronologicalGeneratorOpts{
+		generatorOpts: generatorOpts{
+			Hashtags:           append(feed.MainTags, feed.OtherTags...),
+			DisallowedHashtags: defaultDisallowedHashtags,
+		},
+	}))
+}
+
+func registerConFeeds(r *Service) {
+	r.registerChronologicalConFeed(conFeed{
+		ID:       "denfur",
+		Name:     "DenFur",
+		MainTags: []string{"denfur", "denfur2026"},
+	})
+	r.registerChronologicalConFeed(conFeed{
+		ID:   "eurofurence",
+		Name: "Eurofurence",
+		MainTags: []string{
+			"eurofurence", "eurofurence2025", "eurofurence29",
+			"ef", "ef2025", "ef29",
+		},
+		OtherTags: []string{
+			"eurofurence2023", "eurofurence27", "ef2023", "ef27",
+			"eurofurence2024", "eurofurence28", "ef2024", "ef28",
+			"euroference",
+		},
+	})
+	r.registerChronologicalConFeed(conFeed{
+		ID:       "blfc",
+		Name:     "BLFC",
+		MainTags: []string{"blfc", "blfc26", "blfc2026"},
+		OtherTags: []string{
+			"blfc25", "blfc2025",
+		},
+	})
+	r.registerChronologicalConFeed(conFeed{
+		ID:       "mff",
+		Name:     "MFF",
+		MainTags: []string{"furfest", "mff", "mff26", "mff2026"},
+		OtherTags: []string{
+			"furfest24", "furfest2024", "mff24", "mff2024",
+			"furfest25", "furfest2025", "mff25", "mff2025",
+			"furfest26", "furfest2026",
+		},
+	})
+	r.registerChronologicalConFeed(conFeed{
+		ID:       "fc",
+		Name:     "FC",
+		MainTags: []string{"fc", "fc26", "fc2026"},
+		OtherTags: []string{
+			"furcon26", "furcon2026",
+			"furtherconfusion", "furtherconfusion26", "furtherconfusion2026",
+		},
+	})
+	r.registerChronologicalConFeed(conFeed{
+		ID:       "nfc",
+		Name:     "NFC",
+		MainTags: []string{"nfc", "nfc26", "nfc2026"},
+		OtherTags: []string{
+			"nordicfuzzcon", "nordicfuzzcon26", "nordicfuzzcon2026",
+		},
+	})
+	r.registerChronologicalConFeed(conFeed{
+		ID:       "fwa",
+		Name:     "FWA",
+		MainTags: []string{"fwa", "fwa26", "fwa2026", "furryweekend"},
+		OtherTags: []string{
+			"fwa25", "fwa2025",
+		},
+	})
+	r.registerChronologicalConFeed(conFeed{
+		ID:       "ac",
+		Name:     "Anthrocon",
+		MainTags: []string{"anthrocon", "anthrocon2026", "ac"},
+		OtherTags: []string{
+			"anthrocon26", "ac2026", "ac26",
+		},
+	})
+	r.registerChronologicalConFeed(conFeed{
+		ID:       "lvfc",
+		Name:     "LVFC",
+		MainTags: []string{"lvfc", "lvfc26"},
+		OtherTags: []string{
+			"lasvegasfurcon", "lvfc2026",
+		},
+	})
+}

--- a/feed/feed.go
+++ b/feed/feed.go
@@ -14,6 +14,8 @@ import (
 	"github.com/strideynet/bsky-furry-feed/tristate"
 )
 
+const PawEmoji = "🐾"
+
 var feedRequestMetric = promauto.NewSummaryVec(prometheus.SummaryOpts{
 	Name: "bff_feed_request_duration_seconds",
 	Help: "A very rudimentary way of tracking how many feed skeletons have been requested and how long it takes to serve.",
@@ -464,125 +466,7 @@ func ServiceWithDefaultFeeds(pgxStore *store.PGXStore) *Service {
 			DisallowedHashtags: defaultDisallowedHashtags,
 		},
 	}))
-	r.Register(Meta{
-		ID:          "con-denfur",
-		DisplayName: "🐾 DenFur 2026",
-		Description: "A feed for all things DenFur! Use #denfur or #denfur2026 to include a post in the feed.\n\nJoin the furry feeds by following @furryli.st",
-	}, chronologicalGenerator(chronologicalGeneratorOpts{
-		generatorOpts: generatorOpts{
-			Hashtags:           []string{"denfur", "denfur2026"},
-			DisallowedHashtags: defaultDisallowedHashtags,
-		},
-	}))
-	r.Register(Meta{
-		ID:          "con-eurofurence",
-		DisplayName: "🐾 Eurofurence",
-		Description: "A feed for all things Eurofurence! Use #eurofurence, #eurofurence2025, #eurofurence29, #ef, #ef2025, or #ef29 to include a post in the feed.\n\nJoin the furry feeds by following @furryli.st",
-	}, chronologicalGenerator(chronologicalGeneratorOpts{
-		generatorOpts: generatorOpts{
-			Hashtags: []string{
-				"eurofurence", "ef",
-				"eurofurence2023", "eurofurence27", "ef2023", "ef27",
-				"eurofurence2024", "eurofurence28", "ef2024", "ef28",
-				"eurofurence2025", "eurofurence29", "ef2025", "ef29",
-				// I typoed this like 5 times while making this feed so I'm adding these corrections
-				"euroference",
-			},
-			DisallowedHashtags: defaultDisallowedHashtags,
-		},
-	}))
-	r.Register(Meta{
-		ID:          "con-blfc",
-		DisplayName: "🐾 BLFC 2026",
-		Description: "A feed for all things BLFC! Use #blfc, #blfc26, or #blfc2026 to include a post in the feed.\n\nJoin the furry feeds by following @furryli.st",
-	}, chronologicalGenerator(chronologicalGeneratorOpts{
-		generatorOpts: generatorOpts{
-			Hashtags: []string{
-				"blfc", "blfc25", "blfc2025",
-				"blfc26", "blfc2026",
-			},
-			DisallowedHashtags: defaultDisallowedHashtags,
-		},
-	}))
-	r.Register(Meta{
-		ID:          "con-mff",
-		DisplayName: "🐾 MFF 2026",
-		Description: "A feed for all things MFF! Use #furfest, #mff, #mff26, or #mff2026 to include a post in the feed.\n\nJoin the furry feeds by following @furryli.st",
-	}, chronologicalGenerator(chronologicalGeneratorOpts{
-		generatorOpts: generatorOpts{
-			Hashtags: []string{
-				"furfest", "mff",
-				"furfest24", "furfest2024", "mff24", "mff2024",
-				"furfest25", "furfest2025", "mff25", "mff2025",
-				"furfest26", "furfest2026", "mff26", "mff2026",
-			},
-			DisallowedHashtags: defaultDisallowedHashtags,
-		},
-	}))
-	r.Register(Meta{
-		ID:          "con-fc",
-		DisplayName: "🐾 FC 2026",
-		Description: "A feed for all things FC! Use #fc, #fc26, or #fc2026 to include a post in the feed.\n\nJoin the furry feeds by following @furryli.st",
-	}, chronologicalGenerator(chronologicalGeneratorOpts{
-		generatorOpts: generatorOpts{
-			Hashtags: []string{
-				"fc", "fc26", "fc2026", "furcon26", "furcon2026",
-				"furtherconfusion", "furtherconfusion26", "furtherconfusion2026",
-			},
-			DisallowedHashtags: defaultDisallowedHashtags,
-		},
-	}))
-	r.Register(Meta{
-		ID:          "con-nfc",
-		DisplayName: "🐾 NFC 2026",
-		Description: "A feed for all things NFC! Use #nfc, #nfc26, or #nfc2026 to include a post in the feed.\n\nJoin the furry feeds by following @furryli.st",
-	}, chronologicalGenerator(chronologicalGeneratorOpts{
-		generatorOpts: generatorOpts{
-			Hashtags: []string{
-				"nfc", "nfc26", "nfc2026",
-				"nordicfuzzcon", "nordicfuzzcon26", "nordicfuzzcon2026",
-			},
-			DisallowedHashtags: defaultDisallowedHashtags,
-		},
-	}))
-	r.Register(Meta{
-		ID:          "con-fwa",
-		DisplayName: "🐾 FWA 2026",
-		Description: "A feed for all things FWA! Use #fwa, #fwa26, #fwa2026, or #furryweekend to include a post in the feed.\n\nJoin the furry feeds by following @furryli.st",
-	}, chronologicalGenerator(chronologicalGeneratorOpts{
-		generatorOpts: generatorOpts{
-			Hashtags: []string{
-				"fwa", "fwa25", "fwa2025", "furryweekend",
-				"fwa", "fwa26", "fwa2026", "furryweekend",
-			},
-			DisallowedHashtags: defaultDisallowedHashtags,
-		},
-	}))
-	r.Register(Meta{
-		ID:          "con-ac",
-		DisplayName: "🐾 Anthrocon 2026",
-		Description: "A feed for all things Anthrocon! Use #anthrocon, #anthrocon2026, or #ac to include a post in the feed.\n\nJoin the furry feeds by following @furryli.st",
-	}, chronologicalGenerator(chronologicalGeneratorOpts{
-		generatorOpts: generatorOpts{
-			Hashtags: []string{
-				"anthrocon", "anthrocon2026", "anthrocon26",
-				"ac", "ac2026", "ac26",
-			},
-			DisallowedHashtags: defaultDisallowedHashtags,
-		},
-	}))
-	r.Register(Meta{
-		ID:          "con-lvfc",
-		DisplayName: "🐾 Las Vegas Fur Con 2026",
-		Description: "A feed for all things LVFC! Use #lvfc or #lvfc26 to include a post in the feed.\n\nJoin the furry feeds by following @furryli.st",
-	}, chronologicalGenerator(chronologicalGeneratorOpts{
-		generatorOpts: generatorOpts{
-			Hashtags: []string{
-				"lvfc", "lasvegasfurcon", "lvfc2026", "lvfc26",
-			},
-			DisallowedHashtags: defaultDisallowedHashtags,
-		},
-	}))
+	registerConFeeds(r)
 	r.Register(Meta{
 		ID:          "merch",
 		DisplayName: "🐾 #FurSale",


### PR DESCRIPTION
This adds a helper (`registerChronologicalConFeed`) for registering common con feeds, so a con feed can be registered in just six lines using the same description copy for each feed without copy-pasting.

This also adds a `bffctl bsky list-feeds` command to list all feeds in YAML, so we can compare the changes.

## Feed changes

We're standardizing how feeds look, so every feed now has the same title (`[Name] [Year]`). The only two affected feed display names are the EF and LVFC feeds.

```diff
diff --git a/before.yaml b/after.yaml
index 9be53a3..312f508 100644
--- a/before.yaml
+++ b/after.yaml
@@ -62,7 +62,7 @@ priority: 0
 videoonly: false
 
 id: con-eurofurence
-displayname: "\U0001F43E Eurofurence"
+displayname: "\U0001F43E Eurofurence 2026"
 description: |-
   A feed for all things Eurofurence! Use #eurofurence, #eurofurence2025, #eurofurence29, #ef, #ef2025, or #ef29 to include a post in the feed.
 
@@ -89,7 +89,7 @@ priority: 0
 videoonly: false
 
 id: con-lvfc
-displayname: "\U0001F43E Las Vegas Fur Con 2026"
+displayname: "\U0001F43E LVFC 2026"
 description: |-
   A feed for all things LVFC! Use #lvfc or #lvfc26 to include a post in the feed.
```