### PR TITLE
feat(admin): add dropdown to user icon in navbar

### DIFF
--- a/web/admin/components/core/nav.vue
+++ b/web/admin/components/core/nav.vue
@@ -1,8 +1,11 @@
-<script setup>
+<script setup lang="ts">
 import { search } from "~/lib/search";
+import { logout } from "~/lib/auth";
 
 const profile = await useProfile();
 const showSearch = ref(false);
+const showDropdown = ref(false);
+const dropdownRef = ref<HTMLElement>();
 
 const term = ref("");
 async function doSearch() {
@@ -11,6 +14,21 @@ async function doSearch() {
     showSearch.value = false;
   }
 }
+
+function handleClick(e: PointerEvent) {
+  const target = e.target as HTMLElement;
+  if (!dropdownRef.value!.contains(target)) {
+    showDropdown.value = false;
+  }
+}
+
+onMounted(() => {
+  document.addEventListener("click", handleClick);
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener("click", handleClick);
+});
 </script>
 
 <template>
@@ -33,14 +51,35 @@ async function doSearch() {
 
     <div class="ml-auto flex items-center gap-2">
       <shared-search @toggle-search="showSearch = !showSearch" />
-      <nuxt-link href="/settings">
-        <shared-avatar
-          :did="profile.did"
-          :has-avatar="Boolean(profile.avatar)"
-          resize="72x72"
-          :size="32"
-        />
-      </nuxt-link>
+      <div ref="dropdownRef" class="relative">
+        <button type="button" @click="showDropdown = !showDropdown">
+          <shared-avatar
+            :did="profile.did"
+            :has-avatar="Boolean(profile.avatar)"
+            resize="72x72"
+            :size="32"
+          />
+        </button>
+        <div
+          v-if="showDropdown"
+          class="absolute right-0 w-[150px] bg-white dark:bg-slate-600 rounded-lg overflow-hidden top-full mt-1 border dark:border-gray-700"
+          role="menu"
+        >
+          <nuxt-link
+            href="/settings"
+            class="w-full hover:bg-gray-100 hover:dark:bg-slate-700 px-2 py-1 cursor-pointer flex items-center gap-1 border-b dark:border-gray-700"
+            @click="showDropdown = false"
+          >
+            <icon-settings /> Settings
+          </nuxt-link>
+          <nuxt-link
+            class="w-full hover:bg-gray-100 hover:dark:bg-slate-700 px-2 py-1 cursor-pointer flex items-center gap-1"
+            @click="logout"
+          >
+            <icon-logout /> Log out
+          </nuxt-link>
+        </div>
+      </div>
     </div>
   </nav>
   <div

--- a/web/admin/components/icon/logout.vue
+++ b/web/admin/components/icon/logout.vue
@@ -1,0 +1,15 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1em"
+    height="1em"
+    viewBox="0 0 24 24"
+  >
+    <!-- Icon from Feather Icon by Megumi Hano - https://github.com/feathericon/feathericon/blob/master/LICENSE -->
+    <path
+      fill="currentColor"
+      fillRule="evenodd"
+      d="M3 5c0-1.1.9-2 2-2h8v2H5v14h8v2H5c-1.1 0-2-.9-2-2zm14.176 6L14.64 8.464l1.414-1.414l4.95 4.95l-4.95 4.95l-1.414-1.414L17.176 13H10.59v-2z"
+    />
+  </svg>
+</template>

--- a/web/admin/components/icon/settings.vue
+++ b/web/admin/components/icon/settings.vue
@@ -1,0 +1,14 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1em"
+    height="1em"
+    viewBox="0 0 24 24"
+  >
+    <!-- Icon from Feather Icon by Megumi Hano - https://github.com/feathericon/feathericon/blob/master/LICENSE -->
+    <path
+      fill="currentColor"
+      d="M11 19.938a7.96 7.96 0 0 1-3.906-1.618l-1.458 1.458l-1.414-1.414l1.458-1.458A7.96 7.96 0 0 1 4.062 13H2v-2h2.062A7.96 7.96 0 0 1 5.68 7.094L4.222 5.636l1.414-1.414L7.094 5.68A7.96 7.96 0 0 1 11 4.062V2h2v2.062a7.96 7.96 0 0 1 3.906 1.618l1.458-1.458l1.414 1.414l-1.458 1.458A7.96 7.96 0 0 1 19.938 11H22v2h-2.062a7.96 7.96 0 0 1-1.618 3.906l1.458 1.458l-1.414 1.414l-1.458-1.458A7.96 7.96 0 0 1 13 19.938V22h-2zM12 17a5 5 0 1 0 0-10a5 5 0 0 0 0 10"
+    />
+  </svg>
+</template>

--- a/web/admin/pages/settings.vue
+++ b/web/admin/pages/settings.vue
@@ -4,7 +4,6 @@ import {
   blurNsfwPostMedia,
   useKeyboardShurtcuts,
 } from "~/lib/settings";
-import { logout } from "~/lib/auth";
 </script>
 
 <template>
@@ -44,9 +43,5 @@ import { logout } from "~/lib/auth";
         reject, and <kbd>H</kbd> for hold back</label
       >
     </div>
-
-    <button class="text-white bg-gray-700 px-2 py-1 rounded-lg" @click="logout">
-      Logout
-    </button>
   </div>
 </template>


### PR DESCRIPTION
This adds a dropdown to the user icon in the navbar. Instead of linking to the settings, we now show the dropdown. This makes it easier to log out and makes it less surprising to find the settings page.

## Screenshots

| Light mode | Dark mode |
| --- | --- |
| <img width="189" height="148" alt="image" src="https://github.com/user-attachments/assets/aaa13b51-3967-4d54-8793-0e4bcde95006" /> | <img width="196" height="146" alt="image" src="https://github.com/user-attachments/assets/cb22a948-f6ae-4108-ac66-78a6e0445f17" /> |
