### PR TITLE
chore(deps): upgrade Go to 1.26.4

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.25.6"
+          go-version: "1.26.4"
       - name: Test
         run: go test -race -coverprofile=coverage.txt -covermode=atomic -v ./...
       - name: Upload coverage
@@ -32,12 +32,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.25.6"
+          go-version: "1.26.4"
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.8
+          version: v2.12.2
           args: --timeout=5m
   check-sqlc:
     name: Check sqlc generation
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.25.6"
+          go-version: "1.26.4"
           cache: false
       - name: Install sqlc
         run: go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.30.0

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.25.6"
+          go-version: "1.26.4"
           cache: false
       - name: Deploy feeds
         env:
@@ -65,8 +65,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: furrylist/infra
-          ref: 'main'
-          ssh-key:  ${{ secrets.FURRYLIST_INFRA_DEPLOY_KEY }}
+          ref: "main"
+          ssh-key: ${{ secrets.FURRYLIST_INFRA_DEPLOY_KEY }}
       - uses: jdx/mise-action@v3
       - name: Update release to latest
         run: scripts/release.sh

--- a/bffsrv.Dockerfile
+++ b/bffsrv.Dockerfile
@@ -1,5 +1,5 @@
 ## Build layer
-FROM golang:1.25.6-bookworm AS build
+FROM golang:1.26.4-bookworm AS build
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/strideynet/bsky-furry-feed
 
-go 1.25.6
+go 1.26.4
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.20.0

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "1.25.6"
+go = "1.26.4"
 "go:connectrpc.com/connect/cmd/protoc-gen-connect-go" = "v1.11.0"
 "go:github.com/bufbuild/buf/cmd/buf" = "v1.62.1"
 "go:github.com/golang-migrate/migrate/v4/cmd/migrate" = { version = "4.19.0", tags = "postgres" }
@@ -12,7 +12,7 @@ pnpm = "9.12.3"
 python = "3.8.16"
 "pipx" = "1.7.1"
 "pipx:sqlfluff" = "2.3.2"
-golangci-lint = "2.8.0"
+golangci-lint = "2.12.2"
 prek = "0.3.6"
 
 [tasks]


### PR DESCRIPTION
This upgrades Go from 1.25.6 to 1.26.4, so we can update indigo.
