### PR TITLE
feat(deps): bump indigo to latest version

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -10,13 +10,12 @@ import (
 	"testing"
 
 	"connectrpc.com/connect"
-	indigoTest "github.com/bluesky-social/indigo/testing"
 	"github.com/stretchr/testify/require"
 	"github.com/strideynet/bsky-furry-feed/feed"
 	"github.com/strideynet/bsky-furry-feed/testenv"
 )
 
-func actorAuthInterceptor(actor *indigoTest.TestUser) connect.UnaryInterceptorFunc {
+func actorAuthInterceptor(actor *testenv.TestUser) connect.UnaryInterceptorFunc {
 	token := testenv.ExtractClientFromTestUser(actor).Auth.AccessJwt
 	return func(next connect.UnaryFunc) connect.UnaryFunc {
 		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go/cloudsqlconn v1.20.0
 	connectrpc.com/connect v1.19.1
 	connectrpc.com/otelconnect v0.9.0
-	github.com/bluesky-social/indigo v0.0.0-20260126011129-1e0f4993d59c
+	github.com/bluesky-social/indigo v0.0.0-20260629160527-dfe5578fd537
 	github.com/bluesky-social/jetstream v0.0.0-20260226214936-e0274250f654
 	github.com/docker/go-connections v0.6.0
 	github.com/golang-migrate/migrate/v4 v4.19.1

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932 h1:mXoPYz/Ul5HYE
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
 github.com/bluesky-social/indigo v0.0.0-20260126011129-1e0f4993d59c h1:akc/gte+LLoVv0d8rzULaPLHvDQQchmH3pMyXHaI5+U=
 github.com/bluesky-social/indigo v0.0.0-20260126011129-1e0f4993d59c/go.mod h1:KIy0FgNQacp4uv2Z7xhNkV3qZiUSGuRky97s7Pa4v+o=
+github.com/bluesky-social/indigo v0.0.0-20260629160527-dfe5578fd537 h1:rHaND0argSxgbmE2ix/YuF11xXTtiP3oGUz4fS2Diqo=
+github.com/bluesky-social/indigo v0.0.0-20260629160527-dfe5578fd537/go.mod h1:JqQkz8lrOI6YZivP38GHmtVOTtzsNToITKj1gMpU5Jo=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bradfitz/gomemcache v0.0.0-20250403215159-8d39553ac7cf h1:TqhNAT4zKbTdLa62d2HDBFdvgSbIGB3eJE8HqhgiL9I=

--- a/ingester/ingester_test.go
+++ b/ingester/ingester_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/bluesky-social/indigo/events"
 	"github.com/bluesky-social/indigo/events/schedulers/parallel"
 	lexutil "github.com/bluesky-social/indigo/lex/util"
-	indigoTest "github.com/bluesky-social/indigo/testing"
 	"github.com/bluesky-social/jetstream/pkg/consumer"
 	jetstreamsrv "github.com/bluesky-social/jetstream/pkg/server"
 	"github.com/google/go-cmp/cmp"
@@ -111,9 +110,13 @@ func TestFirehoseIngester(t *testing.T) {
 	}, time.Second*10, time.Millisecond*50, "ingester never subscribed to jetstream")
 
 	now := time.Now().UTC().Truncate(time.Millisecond)
+
+	dummyImage := approvedFurry.MustUploadBlob(t, "image/jpeg", []byte("fake image data"))
+	dummyVideo := approvedFurry.MustUploadBlob(t, "video/mp4", []byte("fake video data"))
+
 	testPosts := []struct {
 		name string
-		user *indigoTest.TestUser
+		user *testenv.TestUser
 		post *bsky.FeedPost
 
 		wantPost *gen.CandidatePost
@@ -174,11 +177,7 @@ func TestFirehoseIngester(t *testing.T) {
 				Text:          "i love to poast #fursuit #murrsuit #furryart #commsopen #nsfw #bigBurgers",
 				Embed: &bsky.FeedPost_Embed{
 					EmbedVideo: &bsky.EmbedVideo{
-						Video: &lexutil.LexBlob{
-							Size:     6_000_000,
-							Ref:      lexutil.LexLink(indigoTest.RandFakeCid()),
-							MimeType: "video/mp4",
-						},
+						Video: dummyVideo,
 					},
 				},
 			},
@@ -219,7 +218,8 @@ func TestFirehoseIngester(t *testing.T) {
 						LexiconTypeID: "app.bsky.embed.images",
 						Images: []*bsky.EmbedImages_Image{
 							{
-								Alt: "some alt text",
+								Alt:   "some alt text",
+								Image: dummyImage,
 							},
 						},
 					},
@@ -291,7 +291,8 @@ func TestFirehoseIngester(t *testing.T) {
 						LexiconTypeID: "app.bsky.embed.images",
 						Images: []*bsky.EmbedImages_Image{
 							{
-								Alt: "#fursuit #murrsuit #furryart #commsopen #nsfw #bigBurgers",
+								Alt:   "#fursuit #murrsuit #furryart #commsopen #nsfw #bigBurgers",
+								Image: dummyImage,
 							},
 						},
 					},
@@ -407,7 +408,7 @@ func TestFirehoseIngester(t *testing.T) {
 							cmpopts.SortSlices(func(a, b string) bool { return a < b }),
 						),
 					)
-				}, time.Second*5, time.Millisecond*100)
+				}, time.Second*10, time.Millisecond*100)
 			})
 		}
 	})

--- a/testenv/plc.go
+++ b/testenv/plc.go
@@ -1,0 +1,26 @@
+package testenv
+
+import _ "embed"
+
+// plcServerScript is an in-memory PLC server that runs as a co-process inside
+// the PDS container, so we don't need to create records for test accounts
+// in https://plc.directory.
+//
+// It uses @did-plc/lib (already bundled in the PDS image) for full validation
+// including cryptographic signature checking, but it's just a glorified array
+// over HTTP.
+//
+//go:embed plc.js
+var plcServerScript []byte
+
+// pdsEntrypoint starts the in-memory PLC server, waits for it to be ready,
+// then starts the PDS pointing at it.
+const pdsEntrypoint = `
+mkdir -p /pds/blocks
+node /app/plc.js &
+for i in $(seq 1 50); do
+  wget -qO- http://127.0.0.1:2582/_health 2>/dev/null && break
+  sleep 0.1
+done
+node --enable-source-maps index.ts
+`

--- a/testenv/plc.js
+++ b/testenv/plc.js
@@ -1,0 +1,78 @@
+// This file is largely vibecoded to just have a mock PLC server.
+// It's just a glorified array over the network.
+import { createServer } from "http";
+import plc from "/app/node_modules/.pnpm/@did-plc+lib@0.0.4/node_modules/@did-plc/lib/dist/index.js";
+import { cidForCbor } from "/app/node_modules/.pnpm/@did-plc+lib@0.0.4/node_modules/@atproto/common/dist/index.js";
+
+const store = {};
+
+async function validateAndAdd(did, op) {
+  const ops = store[did] || [];
+  const { nullified } = await plc.assureValidNextOp(did, ops, op);
+  const cid = await cidForCbor(op);
+  store[did] = store[did] || [];
+  store[did].push({
+    did,
+    operation: op,
+    cid,
+    nullified: false,
+    createdAt: new Date(),
+  });
+  for (const nullCid of nullified) {
+    for (const entry of store[did]) {
+      if (nullCid.equals(entry.cid)) entry.nullified = true;
+    }
+  }
+}
+
+function lastOp(did) {
+  const ops = (store[did] || []).filter((o) => !o.nullified);
+  return ops.length ? ops[ops.length - 1].operation : null;
+}
+
+const server = createServer(async (req, res) => {
+  const url = new URL(req.url, "http://localhost");
+  const parts = url.pathname.split("/").filter(Boolean);
+  const did = parts[0] ? decodeURIComponent(parts[0]) : null;
+  try {
+    if (req.method === "GET" && url.pathname === "/_health") {
+      res.writeHead(200);
+      res.end(JSON.stringify({ version: "0.0.0" }));
+      return;
+    }
+    if (req.method === "POST" && did) {
+      let body = "";
+      for await (const chunk of req) body += chunk;
+      await validateAndAdd(did, JSON.parse(body));
+      res.writeHead(200);
+      res.end();
+      return;
+    }
+    if (req.method === "GET" && did) {
+      const op = lastOp(did);
+      if (!op) {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+      const data = plc.opToData(did, op);
+      if (!data) {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+      const doc = await plc.formatDidDoc(data);
+      res.writeHead(200, { "content-type": "application/did+ld+json" });
+      res.end(JSON.stringify(doc));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  } catch (err) {
+    res.writeHead(400);
+    res.end(JSON.stringify({ error: err.message }));
+  }
+});
+
+const port = parseInt(process.env.PLC_PORT || "2582", 10);
+server.listen(port, "0.0.0.0", () => process.stdout.write("plc ready\n"));

--- a/testenv/testenv.go
+++ b/testenv/testenv.go
@@ -1,52 +1,75 @@
 package testenv
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
-	"reflect"
 	"testing"
-	"unsafe"
 
 	"github.com/docker/go-connections/nat"
-	"github.com/testcontainers/testcontainers-go/wait"
-
-	"github.com/bluesky-social/indigo/xrpc"
-	"github.com/stretchr/testify/require"
-	"github.com/strideynet/bsky-furry-feed/store"
-
-	indigoTest "github.com/bluesky-social/indigo/testing"
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
-	ipfsLog "github.com/ipfs/go-log"
+	"github.com/stretchr/testify/require"
+	"github.com/strideynet/bsky-furry-feed/store"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
 )
 
-func init() {
-	ipfsLog.SetAllLoggers(ipfsLog.LevelDebug)
-}
+func startPDS(ctx context.Context, t *testing.T) *TestPDS {
+	t.Helper()
 
-// black magic to set an unexported field on the TestRelay
-func setTrialHostOnRelay(trelay *indigoTest.TestRelay, rawHost string) {
-	hosts := []string{rawHost}
+	const pdsPort = "3000/tcp"
 
-	trialHosts := reflect.ValueOf(trelay).
-		Elem().FieldByName("tr").
-		Elem().FieldByName("TrialHosts")
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "ghcr.io/bluesky-social/pds:0.4.5009",
+			ExposedPorts: []string{pdsPort},
+			Env: map[string]string{
+				"PDS_HOSTNAME":       "localhost",
+				"PDS_JWT_SECRET":     "test-jwt-secret-not-for-production",
+				"PDS_ADMIN_PASSWORD": "admin",
+				"PDS_PLC_ROTATION_KEY_K256_PRIVATE_KEY_HEX": "3ee68ca7de7f9af37d9e02a21f3c49de87d4e7c2aa6c6e8a1c26e2f1e8bb8a7f",
+				"PDS_DATA_DIRECTORY":                        "/pds",
+				"PDS_BLOBSTORE_DISK_LOCATION":               "/pds/blocks",
+				"PDS_DID_PLC_URL":                           "http://127.0.0.1:2582",
+				"PDS_DEV_MODE":                              "true",
+				"PDS_INVITE_REQUIRED":                       "false",
+				"PDS_SERVICE_HANDLE_DOMAINS":                ".tpds",
+				"NODE_ENV":                                  "production",
 
-	reflect.NewAt(
-		trialHosts.Type(),
-		unsafe.Pointer(trialHosts.UnsafeAddr())).Elem().Set(reflect.ValueOf(hosts))
-}
+				// just in case we want to run against the public app view
+				// "PDS_BSKY_APP_VIEW_URL": "https://api.bsky.app",
+				// "PDS_BSKY_APP_VIEW_DID": "did:web:api.bsky.app",
+			},
+			Entrypoint: []string{"sh", "-c", pdsEntrypoint},
+			Files: []testcontainers.ContainerFile{
+				{
+					Reader:            bytes.NewReader(plcServerScript),
+					ContainerFilePath: "/app/plc.js",
+					FileMode:          0o644,
+				},
+			},
+			WaitingFor: wait.ForHTTP("/xrpc/com.atproto.server.describeServer").WithPort(nat.Port(pdsPort)),
+		},
+		Started: true,
+	})
+	require.NoError(t, err, "starting PDS container")
+	t.Cleanup(func() {
+		require.NoError(t, container.Terminate(context.Background()))
+	})
 
-func ExtractClientFromTestUser(user *indigoTest.TestUser) *xrpc.Client {
-	// This isn't exposed by indigo so we have to use reflection to access the
-	// client.
-	val := reflect.ValueOf(user).Elem().FieldByName("client")
-	iface := reflect.NewAt(val.Type(), unsafe.Pointer(val.UnsafeAddr())).Elem().Interface()
-	return iface.(*xrpc.Client)
+	mappedPort, err := container.MappedPort(ctx, nat.Port(pdsPort))
+	require.NoError(t, err, "getting PDS port")
+
+	host, err := container.Host(ctx)
+	require.NoError(t, err, "getting PDS host")
+
+	return &TestPDS{
+		rawHost: fmt.Sprintf("%s:%d", host, mappedPort.Int()),
+	}
 }
 
 func StartDatabase(ctx context.Context, t *testing.T) (url string) {
@@ -83,23 +106,13 @@ func StartDatabase(ctx context.Context, t *testing.T) (url string) {
 }
 
 type Harness struct {
-	PDS   *indigoTest.TestPDS
-	Relay *indigoTest.TestRelay
+	PDS   *TestPDS
 	Store *store.PGXStore
 }
 
 func StartHarness(ctx context.Context, t *testing.T) *Harness {
 	dbURL := StartDatabase(ctx, t)
-
-	didr := indigoTest.TestPLC(t)
-
-	pds := indigoTest.MustSetupPDS(t, ".tpds", didr)
-	pds.Run(t)
-	t.Cleanup(pds.Cleanup)
-
-	relay := indigoTest.MustSetupRelay(t, didr, true)
-	relay.Run(t)
-	setTrialHostOnRelay(relay, pds.RawHost())
+	pds := startPDS(ctx, t)
 
 	pgxStore, err := store.ConnectPGXStore(
 		ctx,
@@ -110,7 +123,6 @@ func StartHarness(ctx context.Context, t *testing.T) *Harness {
 	t.Cleanup(pgxStore.Close)
 
 	return &Harness{
-		Relay: relay,
 		PDS:   pds,
 		Store: pgxStore,
 	}

--- a/testenv/testpds.go
+++ b/testenv/testpds.go
@@ -1,0 +1,59 @@
+package testenv
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	comatproto "github.com/bluesky-social/indigo/api/atproto"
+	"github.com/bluesky-social/indigo/xrpc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPDS represents a running PDS container for testing.
+type TestPDS struct {
+	rawHost string
+}
+
+// RawHost returns a host:port string for the PDS.
+func (p *TestPDS) RawHost() string {
+	return p.rawHost
+}
+
+// HTTPHost returns the http:// URL for the PDS.
+func (p *TestPDS) HTTPHost() string {
+	u := url.URL{Scheme: "http", Host: p.rawHost}
+	return u.String()
+}
+
+// MustNewUser creates a new account on the PDS and returns a TestUser.
+// Handles must end in ".tpds".
+func (p *TestPDS) MustNewUser(t *testing.T, handle string) *TestUser {
+	t.Helper()
+
+	require.Truef(t, strings.HasSuffix(handle, ".tpds"), "handle %s must end with .tpds", handle)
+
+	ctx := t.Context()
+
+	c := &xrpc.Client{Host: p.HTTPHost()}
+	email := handle + "@test.invalid"
+	pass := "password"
+	out, err := comatproto.ServerCreateAccount(ctx, c, &comatproto.ServerCreateAccount_Input{
+		Email:    &email,
+		Handle:   handle,
+		Password: &pass,
+	})
+	require.NoError(t, err, "creating test user %q", handle)
+
+	c.Auth = &xrpc.AuthInfo{
+		AccessJwt:  out.AccessJwt,
+		RefreshJwt: out.RefreshJwt,
+		Handle:     out.Handle,
+		Did:        out.Did,
+	}
+
+	return &TestUser{
+		did:    out.Did,
+		client: c,
+	}
+}

--- a/testenv/testuser.go
+++ b/testenv/testuser.go
@@ -1,0 +1,43 @@
+package testenv
+
+import (
+	"bytes"
+	"testing"
+
+	comatproto "github.com/bluesky-social/indigo/api/atproto"
+	lexutil "github.com/bluesky-social/indigo/lex/util"
+	"github.com/bluesky-social/indigo/xrpc"
+	"github.com/stretchr/testify/require"
+)
+
+// ExtractClientFromTestUser returns the xrpc client for a test user.
+func ExtractClientFromTestUser(user *TestUser) *xrpc.Client {
+	return user.client
+}
+
+// TestUser represents a user account on the test PDS.
+type TestUser struct {
+	did    string
+	client *xrpc.Client
+}
+
+// DID returns the user's DID.
+func (u *TestUser) DID() string {
+	return u.did
+}
+
+// Client returns the authenticated xrpc client for this user.
+func (u *TestUser) Client() *xrpc.Client {
+	return u.client
+}
+
+// MustUploadBlob uploads data with the given MIME type to the PDS and returns
+// the resulting [lexutil.LexBlob]. Required when constructing posts with embeds, since
+// the PDS validates that blob refs point to previously uploaded blobs.
+func (u *TestUser) MustUploadBlob(t *testing.T, mimeType string, data []byte) *lexutil.LexBlob {
+	t.Helper()
+	var out comatproto.RepoUploadBlob_Output
+	err := u.client.LexDo(t.Context(), "POST", mimeType, "com.atproto.repo.uploadBlob", nil, bytes.NewReader(data), &out)
+	require.NoError(t, err, "uploading blob")
+	return out.Blob
+}


### PR DESCRIPTION
This bumps indigo to the latest version.

To achieve that, we need to fully replace the `indigo/testing` package because indigo no longer ships with a test PDS or relay.

We now start our own PDS. It runs its own PLC directory, so we avoid registering our test accounts with the `plc.directory`. We don't run our own relay anymore but we can just sync via the jetstream with the PDS directly.

This _is_ an ugly fix but at least we're using a real PDS now.
