### PR TITLE
feat(ingester): treat posts with gallery as media

### DIFF
--- a/ingester/handle_feed_post.go
+++ b/ingester/handle_feed_post.go
@@ -24,24 +24,45 @@ func postTextWithAlts(data *bsky.FeedPost) string {
 	buf.WriteString(data.Text)
 
 	// Collect alt texts when only images are embedded
-	if data.Embed != nil && data.Embed.EmbedImages != nil {
-		for _, image := range data.Embed.EmbedImages.Images {
-			if image.Alt == "" {
-				continue
+	if data.Embed != nil {
+		if data.Embed.EmbedImages != nil {
+			for _, image := range data.Embed.EmbedImages.Images {
+				if image.Alt == "" {
+					continue
+				}
+				buf.WriteRune('\n')
+				buf.WriteString(image.Alt)
 			}
-			buf.WriteRune('\n')
-			buf.WriteString(image.Alt)
 		}
-	}
 
-	// Collect alt texts when images and a post is embedded (e.g a quote post that also includes an image)
-	if data.Embed != nil && data.Embed.EmbedRecordWithMedia != nil && data.Embed.EmbedRecordWithMedia.Media != nil && data.Embed.EmbedRecordWithMedia.Media.EmbedImages != nil {
-		for _, image := range data.Embed.EmbedRecordWithMedia.Media.EmbedImages.Images {
-			if image.Alt == "" {
-				continue
+		if data.Embed.EmbedGallery != nil {
+			for _, item := range data.Embed.EmbedGallery.Items {
+				if item.EmbedGallery_Image != nil && item.EmbedGallery_Image.Alt != "" {
+					buf.WriteRune('\n')
+					buf.WriteString(item.EmbedGallery_Image.Alt)
+				}
 			}
-			buf.WriteRune('\n')
-			buf.WriteString(image.Alt)
+		}
+
+		if data.Embed.EmbedRecordWithMedia != nil && data.Embed.EmbedRecordWithMedia.Media != nil {
+			// Collect alt texts when images and a post is embedded (e.g a quote post that also includes an image)
+			if data.Embed.EmbedRecordWithMedia.Media.EmbedImages != nil {
+				for _, image := range data.Embed.EmbedRecordWithMedia.Media.EmbedImages.Images {
+					if image.Alt == "" {
+						continue
+					}
+					buf.WriteRune('\n')
+					buf.WriteString(image.Alt)
+				}
+			}
+			if data.Embed.EmbedRecordWithMedia.Media.EmbedGallery != nil {
+				for _, item := range data.Embed.EmbedRecordWithMedia.Media.EmbedGallery.Items {
+					if item.EmbedGallery_Image != nil && item.EmbedGallery_Image.Alt != "" {
+						buf.WriteRune('\n')
+						buf.WriteString(item.EmbedGallery_Image.Alt)
+					}
+				}
+			}
 		}
 	}
 
@@ -50,7 +71,9 @@ func postTextWithAlts(data *bsky.FeedPost) string {
 
 func hasMedia(data *bsky.FeedPost) bool {
 	return data.Embed != nil && ((data.Embed.EmbedImages != nil && len(data.Embed.EmbedImages.Images) > 0) ||
-		(data.Embed.EmbedRecordWithMedia != nil && data.Embed.EmbedRecordWithMedia.Media != nil && data.Embed.EmbedRecordWithMedia.Media.EmbedImages != nil && len(data.Embed.EmbedRecordWithMedia.Media.EmbedImages.Images) > 0))
+		(data.Embed.EmbedRecordWithMedia != nil && data.Embed.EmbedRecordWithMedia.Media != nil && data.Embed.EmbedRecordWithMedia.Media.EmbedImages != nil && len(data.Embed.EmbedRecordWithMedia.Media.EmbedImages.Images) > 0) ||
+		(data.Embed.EmbedGallery != nil && len(data.Embed.EmbedGallery.Items) > 0) ||
+		(data.Embed.EmbedRecordWithMedia != nil && data.Embed.EmbedRecordWithMedia.Media != nil && data.Embed.EmbedRecordWithMedia.Media.EmbedGallery != nil && len(data.Embed.EmbedRecordWithMedia.Media.EmbedGallery.Items) > 0))
 }
 
 func hasVideo(data *bsky.FeedPost) bool {

--- a/ingester/ingester_test.go
+++ b/ingester/ingester_test.go
@@ -251,6 +251,53 @@ func TestFirehoseIngester(t *testing.T) {
 			},
 		},
 		{
+			name: "post with gallery",
+			user: approvedFurry,
+			post: &bsky.FeedPost{
+				LexiconTypeID: "app.bsky.feed.post",
+				CreatedAt:     now.Format(time.RFC3339Nano),
+				Text:          "poasting galley in #gallery #art",
+				Embed: &bsky.FeedPost_Embed{
+					EmbedGallery: &bsky.EmbedGallery{
+						Items: []*bsky.EmbedGallery_Items_Elem{
+							{
+								EmbedGallery_Image: &bsky.EmbedGallery_Image{
+									Alt:   "so #woof so #gay",
+									Image: dummyImage,
+									AspectRatio: &bsky.EmbedDefs_AspectRatio{
+										Height: 100,
+										Width:  100,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantPost: &gen.CandidatePost{
+				ActorDID: approvedFurry.DID(),
+				CreatedAt: pgtype.Timestamptz{
+					Time:  now,
+					Valid: true,
+				},
+				Hashtags: []string{
+					"gallery",
+					"art",
+					"woof",
+					"gay",
+				},
+				HasMedia: pgtype.Bool{
+					Bool:  true,
+					Valid: true,
+				},
+				HasVideo: pgtype.Bool{
+					Bool:  false,
+					Valid: true,
+				},
+				SelfLabels: []string{},
+			},
+		},
+		{
 			name: "internationalised hashtags",
 			user: approvedFurry,
 			post: &bsky.FeedPost{


### PR DESCRIPTION
This resolves #326 by adding support for posts with a gallery. We treat these posts as media posts now, so they show up in media-only feeds, such as the art feeds.