### PR TITLE
refactor: stop deadnaming relays

### DIFF
--- a/bluesky/bgs_client.go
+++ b/bluesky/bgs_client.go
@@ -11,17 +11,17 @@ import (
 	typegen "github.com/whyrusleeping/cbor-gen"
 )
 
-const DefaultBGSHost = "https://bsky.network"
+const DefaultRelayHost = "https://bsky.network"
 
-type BGSClient struct {
-	BGSHost string
+type RelayClient struct {
+	RelayHost string
 }
 
-func (c *BGSClient) xrpcClient() *xrpc.Client {
+func (c *RelayClient) xrpcClient() *xrpc.Client {
 	ua := UserAgent
-	host := c.BGSHost
+	host := c.RelayHost
 	if host == "" {
-		host = DefaultBGSHost
+		host = DefaultRelayHost
 	}
 	return &xrpc.Client{
 		Host:      host,
@@ -29,9 +29,9 @@ func (c *BGSClient) xrpcClient() *xrpc.Client {
 	}
 }
 
-// SyncGetRecord invokes the `SyncGetRecord` RPC against the BGS, and then
+// SyncGetRecord invokes the `SyncGetRecord` RPC against the Relay, and then
 // parses the returned CAR to retrieve the record and the current repo rev.
-func (c *BGSClient) SyncGetRecord(
+func (c *RelayClient) SyncGetRecord(
 	ctx context.Context, collection string, actorDID string, rkey string,
 ) (record typegen.CBORMarshaler, repoRev string, err error) {
 	xc := c.xrpcClient()

--- a/bluesky/pds_client.go
+++ b/bluesky/pds_client.go
@@ -19,7 +19,7 @@ import (
 )
 
 // DefaultPDSHost is now the vPDS - be cautious - making calls for user data who
-// aren't on the same PDS as the authenticated account may fail. Use BGS or AppView.
+// aren't on the same PDS as the authenticated account may fail. Use Relay or AppView.
 const DefaultPDSHost = "https://bsky.social"
 
 type tokenInfo struct {

--- a/cmd/bffctl/db.go
+++ b/cmd/bffctl/db.go
@@ -155,7 +155,7 @@ func dbCandidateActorsBackfillProfiles(log *slog.Logger, env *environment) *cli.
 			}
 			defer conn.Close(cctx.Context)
 
-			bgsClient := bluesky.BGSClient{}
+			relayClient := bluesky.RelayClient{}
 
 			db := gen.New(conn)
 			repos, err := db.ListCandidateActorsRequiringProfileBackfill(cctx.Context)
@@ -163,7 +163,7 @@ func dbCandidateActorsBackfillProfiles(log *slog.Logger, env *environment) *cli.
 				return err
 			}
 			for _, r := range repos {
-				record, repoRev, err := bgsClient.SyncGetRecord(cctx.Context, "app.bsky.actor.profile", r.DID, "self")
+				record, repoRev, err := relayClient.SyncGetRecord(cctx.Context, "app.bsky.actor.profile", r.DID, "self")
 				if err != nil {
 					if err2 := (&xrpc.Error{}); !errors.As(err, &err2) || err2.StatusCode != http.StatusNotFound {
 						return fmt.Errorf("getting profile: %w", err)

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -23,16 +23,16 @@ type pdsClient interface {
 	Follow(ctx context.Context, subjectDID string) error
 }
 
-type bgsClient interface {
+type relayClient interface {
 	SyncGetRecord(ctx context.Context, collection string, actorDID string, rkey string) (record typegen.CBORMarshaler, repoRev string, err error)
 }
 
 type Worker struct {
-	log       *slog.Logger
-	pdsHost   string
-	pdsClient pdsClient
-	bgsClient bgsClient
-	store     *store.PGXStore
+	log         *slog.Logger
+	pdsHost     string
+	pdsClient   pdsClient
+	relayClient relayClient
+	store       *store.PGXStore
 }
 
 func New(
@@ -46,14 +46,14 @@ func New(
 	if err != nil {
 		return nil, err
 	}
-	bgs := &bluesky.BGSClient{}
+	relay := &bluesky.RelayClient{}
 
 	return &Worker{
-		log:       log,
-		pdsHost:   pdsHost,
-		pdsClient: client,
-		store:     pgxStore,
-		bgsClient: bgs,
+		log:         log,
+		pdsHost:     pdsHost,
+		pdsClient:   client,
+		store:       pgxStore,
+		relayClient: relay,
 	}, nil
 }
 
@@ -123,7 +123,7 @@ func (w *Worker) updateProfileAndFollow(ctx context.Context, actorDid string) er
 }
 
 func (w *Worker) updateProfile(ctx context.Context, actorDid string) error {
-	record, repoRev, err := w.bgsClient.SyncGetRecord(ctx, "app.bsky.actor.profile", actorDid, "self")
+	record, repoRev, err := w.relayClient.SyncGetRecord(ctx, "app.bsky.actor.profile", actorDid, "self")
 	if err != nil {
 		if err2 := (&xrpc.Error{}); !errors.As(err, &err2) || err2.StatusCode != http.StatusNotFound {
 			return fmt.Errorf("getting profile: %w", err)

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -43,22 +43,22 @@ func (m *mockPDS) isFollowed(subjectDID string) bool {
 	return m.Following[subjectDID]
 }
 
-type mockBGS struct {
+type mockRelay struct {
 	sync.Mutex
 	records map[string]typegen.CBORMarshaler
 }
 
-func (m *mockBGS) fullPath(collection string, actorDID string, rkey string) string {
+func (m *mockRelay) fullPath(collection string, actorDID string, rkey string) string {
 	return fmt.Sprintf("%s/%s/%s", actorDID, collection, rkey)
 }
 
-func (m *mockBGS) setRecord(collection string, actorDID string, rkey string, record typegen.CBORMarshaler) {
+func (m *mockRelay) setRecord(collection string, actorDID string, rkey string, record typegen.CBORMarshaler) {
 	m.Lock()
 	defer m.Unlock()
 	m.records[m.fullPath(collection, actorDID, rkey)] = record
 }
 
-func (m *mockBGS) SyncGetRecord(
+func (m *mockRelay) SyncGetRecord(
 	ctx context.Context, collection string, actorDID string, rkey string,
 ) (record typegen.CBORMarshaler, repoRev string, err error) {
 	m.Lock()
@@ -112,19 +112,19 @@ func TestWorker(t *testing.T) {
 	}
 	require.NoError(t, pds.Follow(ctx, alreadyFollowingDID))
 
-	bgs := &mockBGS{
+	relay := &mockRelay{
 		records: map[string]typegen.CBORMarshaler{},
 	}
-	bgs.setRecord("app.bsky.actor.profile", toFollowDID, "self", &bsky.ActorProfile{
+	relay.setRecord("app.bsky.actor.profile", toFollowDID, "self", &bsky.ActorProfile{
 		DisplayName: new("Bob Ross"),
 		Description: new("Happy little trees"),
 	})
 
 	w := Worker{
-		log:       slog.Default(),
-		store:     pgxStore,
-		pdsClient: pds,
-		bgsClient: bgs,
+		log:         slog.Default(),
+		store:       pgxStore,
+		pdsClient:   pds,
+		relayClient: relay,
 	}
 
 	workerDone := make(chan struct{})


### PR DESCRIPTION
This replaces the use of the outdated term "BGS" (short for Big Graph Service) with "Relay" because it is the correct name and was changed over two years ago.

See https://github.com/bluesky-social/atproto/discussions/1847.
