### PR TITLE
feat(ingester): store pending actor records

### DIFF
--- a/ingester/ingester.go
+++ b/ingester/ingester.go
@@ -319,8 +319,8 @@ func (fi *FirehoseIngester) handleRecordCreate(
 	}
 
 	// Only collect events from actors we care about e.g those that are
-	// approved.
-	if actor.Status != v1.ActorStatus_ACTOR_STATUS_APPROVED {
+	// approved and pending.
+	if actor.Status != v1.ActorStatus_ACTOR_STATUS_APPROVED && actor.Status != v1.ActorStatus_ACTOR_STATUS_PENDING {
 		return nil
 	}
 

--- a/ingester/ingester_test.go
+++ b/ingester/ingester_test.go
@@ -52,6 +52,12 @@ func TestFirehoseIngester(t *testing.T) {
 		DID:    pendingFurry.DID(),
 	})
 	require.NoError(t, err)
+	bannedFurry := harness.PDS.MustNewUser(t, "banned-furry.tpds")
+	_, err = harness.Store.CreateActor(ctx, store.CreateActorOpts{
+		Status: bffv1pb.ActorStatus_ACTOR_STATUS_BANNED,
+		DID:    bannedFurry.DID(),
+	})
+	require.NoError(t, err)
 	approvedFurry := harness.PDS.MustNewUser(t, "approvedFurry.tpds")
 	_, err = harness.Store.CreateActor(ctx, store.CreateActorOpts{
 		Status: bffv1pb.ActorStatus_ACTOR_STATUS_APPROVED,
@@ -134,8 +140,34 @@ func TestFirehoseIngester(t *testing.T) {
 			},
 		},
 		{
-			name: "pending furry ignored",
+			name: "pending furry tracked",
 			user: pendingFurry,
+			post: &bsky.FeedPost{
+				LexiconTypeID: "app.bsky.feed.post",
+				CreatedAt:     now.Format(time.RFC3339Nano),
+				Text:          "lorem ipsum dolor sit amet",
+			},
+			wantPost: &gen.CandidatePost{
+				ActorDID: pendingFurry.DID(),
+				CreatedAt: pgtype.Timestamptz{
+					Time:  now,
+					Valid: true,
+				},
+				Hashtags: []string{},
+				HasMedia: pgtype.Bool{
+					Bool:  false,
+					Valid: true,
+				},
+				HasVideo: pgtype.Bool{
+					Bool:  false,
+					Valid: true,
+				},
+				SelfLabels: []string{},
+			},
+		},
+		{
+			name: "banned furry ignored",
+			user: bannedFurry,
 			post: &bsky.FeedPost{
 				LexiconTypeID: "app.bsky.feed.post",
 				CreatedAt:     now.Format(time.RFC3339Nano),
@@ -469,8 +501,10 @@ func TestFirehoseIngester(t *testing.T) {
 		if tp.wantPost != nil {
 			continue
 		}
-		_, err := harness.Store.GetPostByURI(ctx, tp.uri)
-		require.ErrorIs(t, err, store.ErrNotFound)
+		t.Run("ensure_ignored_"+tp.name, func(t *testing.T) {
+			_, err := harness.Store.GetPostByURI(ctx, tp.uri)
+			require.ErrorIs(t, err, store.ErrNotFound)
+		})
 	}
 
 	// Ensure ingester closes properly


### PR DESCRIPTION
We often tell furs after approving their account in a ticket that their
future posts will show up on the feeds.

Therefore, this also stores records from pending actors in the database,
so after approving, their posts will immediately show on the feeds when
they are approved.
