### PR TITLE
feat: allow feeds to filter for containing text

### DIFF
--- a/feed/con_feed.go
+++ b/feed/con_feed.go
@@ -7,10 +7,11 @@ import (
 )
 
 type conFeed struct {
-	ID        string
-	Name      string
-	MainTags  []string
-	OtherTags []string
+	ID           string
+	Name         string
+	MainTags     []string
+	OtherTags    []string
+	TextContains string
 }
 
 // registerChronologicalConFeed registers a con feed (with con- prefix).
@@ -136,5 +137,6 @@ func registerConFeeds(r *Service) {
 			"auraracon", "aurawar", "aurawar26", "aurawar2026",
 			"auwara", "auwara26", "auwara2026",
 		},
+		TextContains: "aurawra",
 	})
 }

--- a/feed/feed.go
+++ b/feed/feed.go
@@ -97,6 +97,7 @@ func (s *Service) GetFeedPosts(ctx context.Context, feedKey string, cursor strin
 
 type generatorOpts struct {
 	Hashtags           []string
+	TextContains       string
 	DisallowedHashtags []string
 	IsNSFW             tristate.Tristate
 	AllowedEmbeds      []EmbedType
@@ -140,6 +141,7 @@ func chronologicalGenerator(opts chronologicalGeneratorOpts) GenerateFunc {
 			AllowedEmbeds:      allowedEmbeds,
 			PinnedDIDs:         opts.PinnedDIDs,
 			CursorTime:         cursorTime,
+			TextContains:       opts.TextContains,
 		}
 
 		storePosts, err := pgxStore.ListPostsForNewFeed(ctx, params)

--- a/feed/feed_test.go
+++ b/feed/feed_test.go
@@ -58,6 +58,9 @@ func TestGenerator(t *testing.T) {
 		},
 		{
 			URI: textPost,
+			Raw: &bsky.FeedPost{
+				Text: "fursuit",
+			},
 		},
 		{
 			URI:       oldPost,
@@ -246,6 +249,16 @@ func TestGenerator(t *testing.T) {
 					},
 				},
 				expectedPosts: []string{nsfwVideoPost, nsfwArtVideoPost},
+			},
+			{
+				name: "text contains",
+				opts: chronologicalGeneratorOpts{
+					generatorOpts: generatorOpts{
+						Hashtags:     []string{"fursuit"},
+						TextContains: "fursuit",
+					},
+				},
+				expectedPosts: []string{textPost, fursuitPost, murrsuitPost},
 			},
 		} {
 			t.Run(test.name, func(t *testing.T) {

--- a/store/gen/candidate_posts.sql.go
+++ b/store/gen/candidate_posts.sql.go
@@ -58,7 +58,7 @@ func (q *Queries) CreateCandidatePost(ctx context.Context, arg CreateCandidatePo
 
 const getFurryNewFeed = `-- name: GetFurryNewFeed :many
 WITH args AS (
-    SELECT $7::TEXT [] AS allowed_embeds
+    SELECT $8::TEXT [] AS allowed_embeds
 )
 
 SELECT cp.uri, cp.actor_did, cp.created_at, cp.indexed_at, cp.is_hidden, cp.deleted_at, cp.raw, cp.hashtags, cp.has_media, cp.self_labels, cp.has_video
@@ -76,16 +76,23 @@ WHERE
     AND (
     -- Standard criteria.
         (
-            -- Match at least one of the queried hashtags.
+            -- Match at least one of the queried hashtags, or the text query.
             -- If unspecified, do not filter.
             (
-                COALESCE($1::TEXT [], '{}') = '{}'
-                OR $1::TEXT [] && cp.hashtags
+                (
+                    COALESCE($1::TEXT [], '{}') = '{}'
+                    OR $1::TEXT [] && cp.hashtags
+                )
+                -- Allow a post to contain a text
+                OR (
+                    $2::TEXT IS NOT NULL
+                    AND cp.raw ->> 'text' ILIKE $2::TEXT
+                )
             )
             -- If any hashtags are disallowed, filter them out.
             AND (
-                COALESCE($2::TEXT [], '{}') = '{}'
-                OR NOT $2::TEXT [] && cp.hashtags
+                COALESCE($3::TEXT [], '{}') = '{}'
+                OR NOT $3::TEXT [] && cp.hashtags
             )
             AND (
                 CARDINALITY(args.allowed_embeds) = 0
@@ -105,27 +112,28 @@ WHERE
             )
             -- Filter by NSFW status. If unspecified, do not filter.
             AND (
-                $3::BOOLEAN IS NULL
+                $4::BOOLEAN IS NULL
                 OR (
                     (ARRAY['nsfw', 'mursuit', 'murrsuit', 'nsfwfurry', 'furrynsfw'] && cp.hashtags)
                     OR (ARRAY['porn', 'nudity', 'sexual'] && cp.self_labels)
-                ) = $3
+                ) = $4
             )
         )
         -- Pinned DID criteria.
-        OR cp.actor_did = ANY($4::TEXT [])
+        OR cp.actor_did = ANY($5::TEXT [])
     )
     -- Remove posts newer than the cursor timestamp
-    AND (cp.indexed_at < $5)
+    AND (cp.indexed_at < $6)
     AND cp.indexed_at > NOW() - INTERVAL '7 day'
     AND cp.created_at > NOW() - INTERVAL '7 day'
 ORDER BY
     cp.indexed_at DESC
-LIMIT $6
+LIMIT $7
 `
 
 type GetFurryNewFeedParams struct {
 	Hashtags           []string
+	TextContains       pgtype.Text
 	DisallowedHashtags []string
 	IsNSFW             pgtype.Bool
 	PinnedDIDs         []string
@@ -137,6 +145,7 @@ type GetFurryNewFeedParams struct {
 func (q *Queries) GetFurryNewFeed(ctx context.Context, arg GetFurryNewFeedParams) ([]CandidatePost, error) {
 	rows, err := q.db.Query(ctx, getFurryNewFeed,
 		arg.Hashtags,
+		arg.TextContains,
 		arg.DisallowedHashtags,
 		arg.IsNSFW,
 		arg.PinnedDIDs,

--- a/store/postgres.go
+++ b/store/postgres.go
@@ -565,6 +565,7 @@ func (s *PGXStore) DeleteFollow(ctx context.Context, opts DeleteFollowOpts) (err
 type ListPostsForNewFeedOpts struct {
 	CursorTime         time.Time
 	Hashtags           []string
+	TextContains       string
 	DisallowedHashtags []string
 	IsNSFW             tristate.Tristate
 	AllowedEmbeds      []string
@@ -596,6 +597,7 @@ func (s *PGXStore) ListPostsForNewFeed(ctx context.Context, opts ListPostsForNew
 		AllowedEmbeds:      opts.AllowedEmbeds,
 		IsNSFW:             tristateToPgtypeBool(opts.IsNSFW),
 		PinnedDIDs:         opts.PinnedDIDs,
+		TextContains:       pgtype.Text{Valid: len(opts.TextContains) > 0, String: opts.TextContains},
 	}
 	if opts.Limit != 0 {
 		queryParams.Limit = int32(opts.Limit)

--- a/store/queries/candidate_posts.sql
+++ b/store/queries/candidate_posts.sql
@@ -42,11 +42,18 @@ WHERE
     AND (
     -- Standard criteria.
         (
-            -- Match at least one of the queried hashtags.
+            -- Match at least one of the queried hashtags, or the text query.
             -- If unspecified, do not filter.
             (
-                COALESCE(sqlc.narg(hashtags)::TEXT [], '{}') = '{}'
-                OR sqlc.arg(hashtags)::TEXT [] && cp.hashtags
+                (
+                    COALESCE(sqlc.narg(hashtags)::TEXT [], '{}') = '{}'
+                    OR sqlc.arg(hashtags)::TEXT [] && cp.hashtags
+                )
+                -- Allow a post to contain a text
+                OR (
+                    sqlc.narg(text_contains)::TEXT IS NOT NULL
+                    AND cp.raw ->> 'text' ILIKE sqlc.narg(text_contains)::TEXT
+                )
             )
             -- If any hashtags are disallowed, filter them out.
             AND (


### PR DESCRIPTION
This allows chronological feeds to specific a `text_contains` match to
include posts in addition to hashtags.

For example, some cons attendees don't use the con hashtags, so just
looking for the con name would be a good alternative, so the feed is
more reflective of all posts related to the con.

We're trying this out with Aurawra because they explicitly asked whether
this is possible.

The biggest problem here is that searching by the non-indexed `text`
column is inefficient and might make the feed very slow.
